### PR TITLE
Remove erroneous typeof value === 'integer'

### DIFF
--- a/src/services/jsonCompletion.ts
+++ b/src/services/jsonCompletion.ts
@@ -621,7 +621,6 @@ export class JSONCompletion {
 				snippetValue = this.getInsertTextForPlainText(snippetValue); // escape \ and }
 				return '"${1:' + snippetValue + '}"' + separatorAfter;
 			case 'number':
-			case 'integer':
 			case 'boolean':
 				return '${1:' + JSON.stringify(value) + '}' + separatorAfter;
 		}


### PR DESCRIPTION
in src/services/jsonCompletion:JSONCompletion.getInsertTextForGuessedValue

This will be an error in an upcoming version of Typescript (2.2 or 2.3 probably).

