### PR TITLE
Include typings from subdirectories

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 .vscode/
 lib/test/
 lib/**/*.js.map
-lib/*/*.d.ts
 src/
 test/
 build/


### PR DESCRIPTION
Removes an `.npmignore` entry that prevents some typing information from being published.

___
Rational:

[vscode-yaml-languageservice](https://github.com/adamvoss/vscode-yaml-languageservice) (powers [vscode-yaml](https://marketplace.visualstudio.com/items?itemName=adamvoss.yaml)) reuses the AST representation from this library to build an AST from a YAML document, and it feeds that representation to services from this library to gain most of the validation and other goodies from this library.

To overcome the lack of published type definitions, **vscode-yaml-languageservice** used `git submodule` to depend directly on the source code from this repository.  While this worked it was inconvenient and fragile (broken by changes in `npm` behavior).

I would really like a better story for managing the **vscode-json-languageservice** dependency that could preferably use `npm` like usual.  This is the easiest solution, requiring the least additional management I have come up with.  I recognize that, even if type information is published, **vscode-yaml-languageservices** is depending on "internal" APIs and breaking changes could occur at any time.

(This has been sparked somewhat by an increased interest in the YAML support provided by **vscode-yaml** [on private channels] and possibly wanting to use the service to add support in other editors).