### PR TITLE
Correct grammar to 'String is not a URI'

### DIFF
--- a/src/parser/jsonParser.ts
+++ b/src/parser/jsonParser.ts
@@ -607,7 +607,7 @@ export class StringASTNode extends ASTNode {
 						validationResult.problems.push({
 							location: { start: this.start, end: this.end },
 							severity: ProblemSeverity.Warning,
-							message: schema.patternErrorMessage || schema.errorMessage || localize('uriFormatWarning', 'String is not an URI: {0}', errorMessage)
+							message: schema.patternErrorMessage || schema.errorMessage || localize('uriFormatWarning', 'String is not a URI: {0}', errorMessage)
 						});
 					}
 				}

--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -548,7 +548,7 @@ suite('JSON Parser', () => {
 
 		semanticErrors = result.validate(schemaWithURI);
 		assert.strictEqual(semanticErrors.length, 1);
-		assert.strictEqual(semanticErrors[0].message, 'String is not an URI: URI with a scheme is expected.');
+		assert.strictEqual(semanticErrors[0].message, 'String is not a URI: URI with a scheme is expected.');
 
 		result = toDocument('{"one":"http://foo/bar"}');
 		semanticErrors = result.validate(schemaWithURI);
@@ -557,12 +557,12 @@ suite('JSON Parser', () => {
 		result = toDocument('{"one":""}');
 		semanticErrors = result.validate(schemaWithURI);
 		assert.strictEqual(semanticErrors.length, 1);
-		assert.strictEqual(semanticErrors[0].message, 'String is not an URI: URI expected.');
+		assert.strictEqual(semanticErrors[0].message, 'String is not a URI: URI expected.');
 
 		result = toDocument('{"one":"//foo/bar"}');
 		semanticErrors = result.validate(schemaWithURI);
 		assert.strictEqual(semanticErrors.length, 1);
-		assert.strictEqual(semanticErrors[0].message, 'String is not an URI: URI with a scheme is expected.');
+		assert.strictEqual(semanticErrors[0].message, 'String is not a URI: URI with a scheme is expected.');
 
 		let schemaWithURIReference = {
 			type: 'object',
@@ -577,7 +577,7 @@ suite('JSON Parser', () => {
 		result = toDocument('{"one":""}');
 		semanticErrors = result.validate(schemaWithURIReference);
 		assert.strictEqual(semanticErrors.length, 1, 'uri-reference');
-		assert.strictEqual(semanticErrors[0].message, 'String is not an URI: URI expected.');
+		assert.strictEqual(semanticErrors[0].message, 'String is not a URI: URI expected.');
 
 		result = toDocument('{"one":"//foo/bar"}');
 		semanticErrors = result.validate(schemaWithURIReference);


### PR DESCRIPTION
Old message was 'String is not an URI'. Unless 'URI' should be pronounced differently from what I'm used to, it should be 'a URI'.