### PR TITLE
fix errors when jsonDocument.syntaxErrors is not defined

### DIFF
--- a/src/services/jsonValidation.ts
+++ b/src/services/jsonValidation.ts
@@ -83,12 +83,14 @@ export class JSONValidation {
 				}
 			}
 
-			jsonDocument.syntaxErrors.forEach(p => {
-				if (p.code === ErrorCode.TrailingComma) {
-					p.severity = trailingCommaSeverity;
-				}
-				addProblem(p);
-			});
+			if (jsonDocument.syntaxErrors) {
+				jsonDocument.syntaxErrors.forEach(p => {
+					if (p.code === ErrorCode.TrailingComma) {
+						p.severity = trailingCommaSeverity;
+					}
+					addProblem(p);
+				});
+			}
 
 			if (commentSeverity !== ProblemSeverity.Ignore) {
 				let message = localize('InvalidCommentToken', 'Comments are not permitted in JSON.');


### PR DESCRIPTION
I found this error in vscode when opening yaml files