### PR TITLE
Fix issue related to jsonDocument.syntaxErrors

### DIFF
--- a/src/services/jsonValidation.ts
+++ b/src/services/jsonValidation.ts
@@ -83,12 +83,14 @@ export class JSONValidation {
 				}
 			}
 
-			jsonDocument.syntaxErrors.forEach(p => {
-				if (p.code === ErrorCode.TrailingComma) {
-					p.severity = trailingCommaSeverity;
-				}
-				addProblem(p);
-			});
+			if (jsonDocument.syntaxErrors) {
+				jsonDocument.syntaxErrors.forEach(p => {
+					if (p.code === ErrorCode.TrailingComma) {
+						p.severity = trailingCommaSeverity;
+					}
+					addProblem(p);
+				});
+			}
 
 			if (commentSeverity !== ProblemSeverity.Ignore) {
 				let message = localize('InvalidCommentToken', 'Comments are not permitted in JSON.');


### PR DESCRIPTION
Got `The YAML Language Server server crashed 5 times in the last 3 minutes. The server will not be restarted.` when started VSCode.

That issue is related to the following error: `.vscode/extensions/adamvoss.yaml-0.0.10/server/node_modules/vscode-json-languageservice/lib/services/jsonValidation.js:47 jsonDocument.syntaxErrors.forEach(addProblem); `
`TypeError: Cannot read property 'forEach' of undefined....`

Added expression to check whether `jsonDocument.syntaxErrors` is defined.

Ran tests. Pass as well.
Linted code. No issues found.