### PR TITLE
fix maxItems validation error message

### DIFF
--- a/src/parser/jsonParser.ts
+++ b/src/parser/jsonParser.ts
@@ -726,7 +726,7 @@ function validate(node: ASTNode, schema: JSONSchema, validationResult: Validatio
 			validationResult.problems.push({
 				location: { offset: node.offset, length: node.length },
 				severity: DiagnosticSeverity.Warning,
-				message: localize('maxItemsWarning', 'Array has too many items. Expected {0} or fewer.', schema.minItems)
+				message: localize('maxItemsWarning', 'Array has too many items. Expected {0} or fewer.', schema.maxItems)
 			});
 		}
 


### PR DESCRIPTION
The message refers to the `minItems` value (incorrect), not the `maxItems` value (correct).

This leads to incorrect validation error messages when using maxItems, such as in the example below (which can occur with `maxItems` is not 0):

> Array has too many items. Expected 0 or fewer.