### PR TITLE
Add a more sensible fallback range if there is no parent property

### DIFF
--- a/src/parser/jsonParser.ts
+++ b/src/parser/jsonParser.ts
@@ -449,7 +449,7 @@ function validate(node: ASTNode, schema: JSONSchema, validationResult: Validatio
 
 			if (matches.length > 1 && maxOneMatch) {
 				validationResult.problems.push({
-					location: { offset: node.offset, length: 1 },
+					location: { offset: node.offset, length: node.length },
 					severity: DiagnosticSeverity.Warning,
 					message: localize('oneOfWarning', "Matches multiple schemas when only one must validate.")
 				});
@@ -792,7 +792,7 @@ function validate(node: ASTNode, schema: JSONSchema, validationResult: Validatio
 			for (const propertyName of schema.required) {
 				if (!seenKeys[propertyName]) {
 					let keyNode = node.parent && node.parent.type === 'property' && node.parent.keyNode;
-					let location = keyNode ? { offset: keyNode.offset, length: keyNode.length } : { offset: node.offset, length: 1 };
+					let location = keyNode ? { offset: keyNode.offset, length: keyNode.length } : { offset: node.offset, length: node.length };
 					validationResult.problems.push({
 						location: location,
 						severity: DiagnosticSeverity.Warning,


### PR DESCRIPTION
EDIT: After some consideration I realise this should be an issue rather than a pull request, as this is not obviously better in all cases.

Before:
```
{"bold":true}
^
Missing property "text"
```
After:
```
{"bold":true}
^^^^^^^^^^^^^
Missing property "text".

This case could occur if the entire document was validated against a schema using `required` or `oneOf`. This would have the disadvantage of making the errors uglier in cases where there is a large document which fails this validation, however only erroring the first character is also not great. Perhaps we should work out an alternative method?