### PR TITLE
More concise error message for schema validation errors

### DIFF
--- a/src/services/jsonSchemaService.ts
+++ b/src/services/jsonSchemaService.ts
@@ -354,7 +354,12 @@ export class JSONSchemaService implements IJSONSchemaService {
 				return new UnresolvedSchema(schemaContent, errors);
 			},
 			(error: any) => {
-				let errorMessage = localize('json.schema.unabletoload', 'Unable to load schema from \'{0}\': {1}', toDisplayString(url), error.toString());
+				let errorMessage = error.toString();
+				let errorSplit = error.toString().split('Error: ');
+				if(errorSplit.length > 1) {
+					// more concise error message, URL and context are attached by caller anyways
+					errorMessage = errorSplit[1];
+				}
 				return new UnresolvedSchema(<JSONSchema>{}, [errorMessage]);
 			}
 		);


### PR DESCRIPTION
#### Ellipsis
The error message shown if a schema could not be retrieved is currently not very concise, it repeats the same sentence three times. This PR shortens it a little.

ref: https://github.com/Microsoft/vscode/pull/60219#issuecomment-428089447 by @aeschli 

Old message:
![bad](https://user-images.githubusercontent.com/547070/46742963-5eb08980-cca8-11e8-9d90-731482272219.png)

New message:
![image](https://user-images.githubusercontent.com/547070/47434188-507f6480-d7a2-11e8-88e6-385695aa6024.png)

How this works is that it strips everything before `Error: ` in the message returned by the backend, if `Error: ` appears in the message. In the messages I observed, the removed part was something like `Unable to connect to <url>: Error: `, which is redundant because it's prepended by the [only caller](https://github.com/Microsoft/vscode-json-languageservice/blob/master/src/services/jsonSchemaService.ts#L404-L405) anyways.

I wasn't sure about the exact desired format of the error message, so if another format is better, I can change it. One issue with the current one is that it doesn't explicitly state that a schema is the problem. However I didn't want to change an already-translated message since translations would need to update.