### PR TITLE
Fixed a bug when comments are allowed but trailing commas aren't

### DIFF
--- a/src/services/jsonValidation.ts
+++ b/src/services/jsonValidation.ts
@@ -77,7 +77,7 @@ export class JSONValidation {
 
 			jsonDocument.syntaxErrors.forEach(p => {
 				if (p.code === ErrorCode.TrailingComma) {
-					if (typeof commentSeverity !== 'number') {
+					if (typeof trailingCommaSeverity !== 'number') {
 						return;
 					}
 					p.severity = trailingCommaSeverity;


### PR DESCRIPTION
This was probably a typo. This change doesn't affect VSCode because in VSCode, either both comments and trailing commas are allowed, or both are not allowed.