### PR TITLE
Add support for loading schemas stored as YAML files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -262,8 +261,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esutils": {
       "version": "2.0.3",
@@ -428,7 +426,6 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -665,8 +662,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "string-width": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "typescript": "^3.6.3"
   },
   "dependencies": {
+    "js-yaml": "^3.13.1",
     "jsonc-parser": "^2.1.1",
     "vscode-languageserver-types": "^3.15.0-next.5",
     "vscode-nls": "^4.1.1",


### PR DESCRIPTION
Originally raised against [redhat-developer/yaml-language-server](https://github.com/redhat-developer/yaml-language-server).
This adds support for loading schemas saved in YAML formatted files, while still preserving the preference for JSON to be loaded first.

The logic here is to attempt to load as JSON first. If loading as JSON fails, attempt loading as YAML. If YAML loading succeeds, clear the list of errors. If YAML loading fails then add the YAML error to the errors array.