### PR TITLE
Fix multipleOf with float

### DIFF
--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -1588,6 +1588,41 @@ suite('JSON Parser', () => {
 		}
 	});
 
+	test('multipleOf with floats', function () {
+		let schema: JsonSchema.JSONSchema = {
+			type: 'array',
+			items: {
+				type: 'number',
+				multipleOf: 2e-4
+			}
+		};
+		{
+			const { textDoc, jsonDoc } = toDocument('[0.0002,0.2,0.64,2e+6,2.2e+10]');
+			const semanticErrors = jsonDoc.validate(textDoc, schema);
+
+			assert.strictEqual(semanticErrors!.length, 0);
+		}
+		{
+			const { textDoc, jsonDoc } = toDocument('[2e-5,2e-10,1e-4]');
+			const semanticErrors = jsonDoc.validate(textDoc, schema);
+
+			assert.strictEqual(semanticErrors!.length, 3);
+		}
+		schema = {
+			type: 'array',
+			items: {
+				type: 'number',
+				multipleOf: 2.000000001
+			}
+		};
+		{
+			const { textDoc, jsonDoc } = toDocument('[2.000000001e5,6.000000003e8]');
+			const semanticErrors = jsonDoc.validate(textDoc, schema);
+
+			assert.strictEqual(semanticErrors!.length, 0);
+		}
+	});
+
 	test('dependencies with array', function () {
 		const schema: JsonSchema.JSONSchema = {
 			type: 'object',


### PR DESCRIPTION
This update improves how floats are handled with multipleOf option, based on @aeschli concept (linked issue).

One more optional change is to replace `val % multipleOf === 0` to `Number.isInteger(val / multipleOf)`, which allows a bit bigger numbers. Edge case example: 
`6000000000300000000 % 20000000001 = 256 // wrong` vs `6000000000300000000 / 20000000001 = 300000000 // fine`

Fix microsoft/vscode#72314