### PR TITLE
fix silent errors on getMatchingSchemas

### DIFF
--- a/src/services/jsonSchemaService.ts
+++ b/src/services/jsonSchemaService.ts
@@ -585,14 +585,18 @@ export class JSONSchemaService implements IJSONSchemaService {
 		if (schema) {
 			return this.promise.resolve(jsonDocument.getMatchingSchemas(schema).filter(s => !s.inverted));
 		}
-		return this.getSchemaForResource(document.uri, jsonDocument).then(schema => {
-			if (schema) {
-				return jsonDocument.getMatchingSchemas(schema.schema).filter(s => !s.inverted);
-			}
-			return [];
+		return new this.promise((resolve, reject) => {
+			this.getSchemaForResource(document.uri, jsonDocument).then(schema => {
+				if (schema && schema.errors.length === 0) {
+					return resolve(jsonDocument.getMatchingSchemas(schema.schema).filter(s => !s.inverted));
+				} else if (schema && schema.errors.length > 0) {
+					return reject(new Error('Errors while loading json schema: ' + schema.errors.join()));
+				}
+
+				return resolve([]);
+			});
 		});
 	}
-
 }
 
 function normalizeId(id: string): string {

--- a/src/test/schema.test.ts
+++ b/src/test/schema.test.ts
@@ -1026,4 +1026,29 @@ suite('JSON Schema', () => {
 		assertMatchingSchema(ms, 14, 'bar');
 	});
 
+	test('getMatchingSchemasReportsError', async function () {
+		const errorSchemaRequestService = (uri: string) => Promise.reject(new Error('could not find file'));
+		const ls = getLanguageService({ workspaceContext, schemaRequestService: errorSchemaRequestService });
+
+		ls.configure({
+			schemas: [
+				{
+					uri: "file:///notfound.schema.json",
+					fileMatch: ["**/file.json"]
+				}
+			]
+		});
+		const testDoc = toDocument(JSON.stringify({ foo: { bar: 1 } }));
+
+		let wasRejected = false;
+		try {
+			await ls.getMatchingSchemas(testDoc.textDoc, testDoc.jsonDoc);
+		} catch (e) {
+			wasRejected = true;
+		}
+
+		if (!wasRejected) {
+			assert.fail('getMatchingSchema was not rejected despite errors while loading schema');
+		}
+	});
 });


### PR DESCRIPTION
Thanks for exposing getMatchingSchemas tot he public! it helped us solve our use case (expanding the json schema with custom attributes)

So this story happened: Seemingly randomly getMatchingSchemas returned only a subset of node we were expecting. What made matters worse, we failed to make a minimal reproduction, which made debugging very hard (we are applying the schema to roughly 10.000 files, the schema itself is split over several files).

Turns out, we had too many open files open at the same time, which blocked schema resolution. Unfortunately these errors were silenced, which made debugging very hard. So I providing this fix in hope to help some other poor soul, hope it gets included :).

I'm not sure what to do if no applicable schema was found (schema == undefined and return: []). Imo this should also fail, but it could imagine use cases where where you would expect this to pass.