### PR TITLE
add deprecation annotation from json schema draft 2019-09

### DIFF
--- a/src/jsonLanguageTypes.ts
+++ b/src/jsonLanguageTypes.ts
@@ -7,10 +7,10 @@ import { JSONWorkerContribution, JSONPath, Segment, CompletionsCollector } from 
 import { JSONSchema } from './jsonSchema';
 import {
 	Range, TextEdit, Color, ColorInformation, ColorPresentation, FoldingRange, FoldingRangeKind, MarkupKind, SelectionRange,
-	Diagnostic, DiagnosticSeverity,
+	Diagnostic, DiagnosticSeverity,	DiagnosticTag,
 	CompletionItem, CompletionItemKind, CompletionList, Position,
 	InsertTextFormat, MarkupContent,
-	SymbolInformation, SymbolKind, DocumentSymbol, Location, Hover, MarkedString, FormattingOptions as LSPFormattingOptions, DefinitionLink
+	SymbolInformation, SymbolKind, DocumentSymbol, Location, Hover, MarkedString, FormattingOptions as LSPFormattingOptions, DefinitionLink,
 } from 'vscode-languageserver-types';
 
 import { TextDocument } from 'vscode-languageserver-textdocument';
@@ -19,10 +19,10 @@ export {
 	TextDocument,
 	Range, TextEdit, JSONSchema, JSONWorkerContribution, JSONPath, Segment, CompletionsCollector,
 	Color, ColorInformation, ColorPresentation, FoldingRange, FoldingRangeKind, SelectionRange,
-	Diagnostic, DiagnosticSeverity,
+	Diagnostic, DiagnosticSeverity, DiagnosticTag,
 	CompletionItem, CompletionItemKind, CompletionList, Position,
 	InsertTextFormat, MarkupContent, MarkupKind, DefinitionLink,
-	SymbolInformation, SymbolKind, DocumentSymbol, Location, Hover, MarkedString
+	SymbolInformation, SymbolKind, DocumentSymbol, Location, Hover, MarkedString,
 };
 
 /**

--- a/src/jsonSchema.ts
+++ b/src/jsonSchema.ts
@@ -53,6 +53,9 @@ export interface JSONSchema {
 	then?: JSONSchemaRef;
 	else?: JSONSchemaRef;
 
+	// schema draft 2019-09
+	deprecated?: boolean;
+
 	// VSCode extensions
 
 	defaultSnippets?: { label?: string; description?: string; markdownDescription?: string; body?: any; bodyText?: string; }[]; // VSCode extension: body: a object that will be converted to a JSON string. bodyText: text with \t and \n

--- a/src/services/jsonCompletion.ts
+++ b/src/services/jsonCompletion.ts
@@ -232,7 +232,7 @@ export class JSONCompletion {
 				if (schemaProperties) {
 					Object.keys(schemaProperties).forEach((key: string) => {
 						const propertySchema = schemaProperties[key];
-						if (typeof propertySchema === 'object' && !propertySchema.deprecationMessage && !propertySchema.doNotSuggest) {
+						if (typeof propertySchema === 'object' && !propertySchema.deprecationMessage && !propertySchema.deprecated && !propertySchema.doNotSuggest) {
 							const proposal: CompletionItem = {
 								kind: CompletionItemKind.Property,
 								label: key,
@@ -255,7 +255,7 @@ export class JSONCompletion {
 					});
 				}
 				const schemaPropertyNames = s.schema.propertyNames;
-				if (typeof schemaPropertyNames === 'object' && !schemaPropertyNames.deprecationMessage && !schemaPropertyNames.doNotSuggest) {
+				if (typeof schemaPropertyNames === 'object' && !schemaPropertyNames.deprecationMessage && !schemaPropertyNames.deprecated && !schemaPropertyNames.doNotSuggest) {
 					const propertyNameCompletionItem = (name: string, enumDescription: string | MarkupContent | undefined = undefined) => {
 						const proposal: CompletionItem = {
 							kind: CompletionItemKind.Property,

--- a/src/test/completion.test.ts
+++ b/src/test/completion.test.ts
@@ -1118,6 +1118,27 @@ suite('JSON Completion', () => {
 		});
 	});
 
+	test('Deprecation without message', async function () {
+		const schema: JSONSchema = {
+			type: 'object',
+			properties: {
+				'prop1': {
+					deprecated: true
+				},
+				'prop2': {
+					type: 'string'
+				},
+			}
+		};
+
+		await testCompletionsFor('{ |', schema, {
+			items: [
+				{ label: 'prop2' },
+				{ label: 'prop1', notAvailable: true }
+			]
+		});
+	});
+
 
 	test('Enum description', async function () {
 		const schema: JSONSchema = {

--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -1721,7 +1721,7 @@ suite('JSON Parser', () => {
 		}
 	});
 
-	test('deprecated', function () {
+	test('deprecated message', function () {
 
 		const { textDoc, jsonDoc } = toDocument('{"prop": 42}');
 
@@ -1730,6 +1730,25 @@ suite('JSON Parser', () => {
 			properties: {
 				'prop': {
 					deprecationMessage: "Prop is deprecated"
+				}
+			}
+		};
+
+		const semanticErrors = jsonDoc.validate(textDoc, schema);
+
+		assert.strictEqual(semanticErrors!.length, 1);
+	});
+
+	
+	test('deprecated', function () {
+
+		const { textDoc, jsonDoc } = toDocument('{"prop": 42}');
+
+		const schema: JSONSchema = {
+			type: 'object',
+			properties: {
+				'prop': {
+					deprecated: true
 				}
 			}
 		};

--- a/src/test/schema.test.ts
+++ b/src/test/schema.test.ts
@@ -1123,11 +1123,15 @@ suite('JSON Schema', () => {
 			assert.strictEqual(jsonDoc.syntaxErrors.length, 0);
 
 			const semanticErrors = await ls.doValidation(textDoc, jsonDoc, { schemaValidation: 'error' }, schema);
-			assert.strictEqual(semanticErrors!.length, 6);
+			assert.strictEqual(semanticErrors!.length, 8);
 			assert.strictEqual(semanticErrors![0].severity, DiagnosticSeverity.Error);
 			assert.strictEqual(semanticErrors![1].severity, DiagnosticSeverity.Error);
 			assert.strictEqual(semanticErrors![2].severity, DiagnosticSeverity.Error);
 			assert.strictEqual(semanticErrors![3].severity, DiagnosticSeverity.Error);
+			assert.strictEqual(semanticErrors![4].severity, DiagnosticSeverity.Hint);
+			assert.strictEqual(semanticErrors![4].tags?.includes(DiagnosticTag.Deprecated), true);
+			assert.strictEqual(semanticErrors![5].severity, DiagnosticSeverity.Hint);
+			assert.strictEqual(semanticErrors![5].tags?.includes(DiagnosticTag.Deprecated), true);
 			assert.strictEqual(semanticErrors![4].severity, DiagnosticSeverity.Hint);
 			assert.strictEqual(semanticErrors![4].tags?.includes(DiagnosticTag.Deprecated), true);
 			assert.strictEqual(semanticErrors![5].severity, DiagnosticSeverity.Hint);


### PR DESCRIPTION
fixes #87 

before:
![2021-02-15 12_17_38-● settings json - vscode-json-languageservice - Visual Studio Code](https://user-images.githubusercontent.com/8685297/107940044-ecdb5f80-6f87-11eb-927f-6810d2ab8438.png)

after:
![2021-02-15 12_04_16-settings json - Code - OSS Dev](https://user-images.githubusercontent.com/8685297/107939527-28295e80-6f87-11eb-935c-813c97b87d91.png)

I've added the deprecation tag to the language service by implementing the "depreated" property from json schema draft 2019-09. The custom "deprecationMessage" also works. Deprecated symbols are now rendered with a strikethrough instead of a warning.

**open questions:** 
I've added a new language snippet "deprecationMessage", I don't know how the translation process is going to work.