### PR TITLE
fix: clear `JsonSchemaService` local single resource cache on schema change

### DIFF
--- a/src/services/jsonSchemaService.ts
+++ b/src/services/jsonSchemaService.ts
@@ -273,6 +273,9 @@ export class JSONSchemaService implements IJSONSchemaService {
 	}
 
 	public onResourceChange(uri: string): boolean {
+		// always clear this local cache when a resource changes
+		this.cachedSchemaForResource = undefined;
+
 		let hasChanges = false;
 		uri = normalizeId(uri);
 


### PR DESCRIPTION
This local cache was not being cleared on a resource change.

Closes #106