### PR TITLE
feat: support number const

### DIFF
--- a/src/services/jsonCompletion.ts
+++ b/src/services/jsonCompletion.ts
@@ -886,7 +886,8 @@ export class JSONCompletion {
 						break;
 					case 'number':
 					case 'integer':
-						value = '${1:0}';
+						let defaultValue = propertySchema.const ?? 0;
+						value = '${1:' + String(defaultValue) +'}';
 						break;
 					case 'null':
 						value = '${1:null}';

--- a/src/services/jsonCompletion.ts
+++ b/src/services/jsonCompletion.ts
@@ -850,6 +850,12 @@ export class JSONCompletion {
 				}
 				nValueProposals += propertySchema.enum.length;
 			}
+			if (isDefined(propertySchema.const)) {
+				if (!value) {
+					value = this.getInsertTextForGuessedValue(propertySchema.const, '');
+				}
+				nValueProposals++;
+			}
 			if (isDefined(propertySchema.default)) {
 				if (!value) {
 					value = this.getInsertTextForGuessedValue(propertySchema.default, '');
@@ -886,8 +892,7 @@ export class JSONCompletion {
 						break;
 					case 'number':
 					case 'integer':
-						const defaultValue = propertySchema.const ?? 0;
-						value = '${1:' + String(defaultValue) +'}';
+						value = '${1:0}';
 						break;
 					case 'null':
 						value = '${1:null}';

--- a/src/services/jsonCompletion.ts
+++ b/src/services/jsonCompletion.ts
@@ -886,7 +886,7 @@ export class JSONCompletion {
 						break;
 					case 'number':
 					case 'integer':
-						let defaultValue = propertySchema.const ?? 0;
+						const defaultValue = propertySchema.const ?? 0;
 						value = '${1:' + String(defaultValue) +'}';
 						break;
 					case 'null':

--- a/src/test/completion.test.ts
+++ b/src/test/completion.test.ts
@@ -354,7 +354,12 @@ suite('JSON Completion', () => {
 					items: {
 						type: 'string'
 					}
-				}
+				},
+				"version": {
+					"type": "number",
+					"const": 2,
+					"markdownDescription": "version",
+				},
 			}
 		};
 		await testCompletionsFor('{ "a": | }', schema, {
@@ -377,6 +382,18 @@ suite('JSON Completion', () => {
 			count: 3,
 			items: [
 				{ label: '"John"', resultText: '{ "a": "John", "b": 1 }' }
+			]
+		});
+		await testCompletionsFor('{ "version": | }', schema, {
+			count: 1,
+			items: [
+				{ label: '2', resultText: '{ "version": 2 }' },
+			]
+		});
+		await testCompletionsFor('{ "version": 2| }', schema, {
+			count: 1,
+			items: [
+				{ label: '2', resultText: '{ "version": 2 }' },
 			]
 		});
 	});


### PR DESCRIPTION
we have a json schema:

```
      "version": {
          "type": "number",
          "const": 2,
          "markdownDescription": "version",
          "description": "version"
        },
```

we want its value can be auto suggestion