### PR TITLE
Don't report "Duplicate object key" when "//" is used for comments

### DIFF
--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -128,6 +128,10 @@ suite('JSON Parser', () => {
 	test('Comments', function () {
 		isValid('/*d*/ { } /*e*/');
 		isInvalid('/*d { }');
+
+		// comments in JSON keys
+		isValid('{ "//": "comment1", "//": "comment2" }');
+		isInvalid('{ "regularKey": "value1", "regularKey": "value2" }', ErrorCode.DuplicateKey, ErrorCode.DuplicateKey);
 	});
 
 	test('Simple AST', function () {


### PR DESCRIPTION
## Background

When a JSON file is intended to be edited by humans (versus serialized over a wire), the best practice is for the parser to support `//` comments:

***JSON comments - best practice***
```js
{
  // The name of the book
  "title": "example",
  // The number of pages in the book
  "pages": 123
}
```
The above practice was [advocated by](https://hashnode.com/post/why-did-douglas-crockford-remove-comments-from-json-cir97ves31fxu2i536bp7u37f) Douglas Crockford, the inventor of JSON.

However because JSON was originally designed for over-the-wire serialization only, today many tools reject `//` comments in human inputs. This is unfortunate -- we all know that it's poor software engineering to write code without comments. 🙂 

To work around this problem, a common convention is to use a JSON key `"//"` like this:

***A convention for less than ideal situations***
```json
{
  "//": "The name of the book",
  "title": "example",

  "//": "The number of pages in the book",
  "pages": 123
}
```

Some random examples of this advice:
- https://medium.com/@marycriv/why-json-doesnt-allow-comments-fe93f7106c62
- [https://firebase.google.com/docs/cloud-messaging/js/client#configure_the_browser_to_receive_messages](https://web.archive.org/web/20170517210432/https://firebase.google.com/docs/cloud-messaging/js/client#configure_the_browser_to_receive_messages)
- https://neil188.github.io/03-12-2018/JSON-comments/

It's true that some JSON parsers will report an error for duplicate object keys (although this is [not stipulated](https://datatracker.ietf.org/doc/html/rfc7159#section-4) by the JSON RFC).  However, those stricter parsers tend to be the full-featured ones that already accept regular `//` comments.  Thus `"//"` works pretty well in practice. 👍

## Purpose of this PR

For modern web development, the most common JSON parsers that reject `//` comments are [JSON.parse()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse) and [require()](https://nodejs.org/en/knowledge/getting-started/what-is-require/), both of which accept `"//"` without any problems.  NPM's `package.json` file is a ubiquitous example that is designed for these APIs, accepts `"//"` comments, and really needs comments because that file can store complex settings data structures. 

This PR supports this use case by preventing IntelliSense warnings in VS Code when editing such config files that contain `"//"` comments.
