### PR TITLE
fix JS inherited property completion

### DIFF
--- a/src/services/jsonCompletion.ts
+++ b/src/services/jsonCompletion.ts
@@ -90,8 +90,7 @@ export class JSONCompletion {
 		const collector: CompletionsCollector = {
 			add: (suggestion: CompletionItem) => {
 				let label = suggestion.label;
-				const existing = proposed[label];
-				if (!existing) {
+				if (!proposed.hasOwnProperty(label)) {
 					label = label.replace(/[\n]/g, '↵');
 					if (label.length > 60) {
 						const shortendedLabel = label.substr(0, 57).trim() + '...';
@@ -109,6 +108,7 @@ export class JSONCompletion {
 					proposed[label] = suggestion;
 					result.items.push(suggestion);
 				} else {
+					const existing = proposed[label];
 					if (!existing.documentation) {
 						existing.documentation = suggestion.documentation;
 					}

--- a/src/services/jsonCompletion.ts
+++ b/src/services/jsonCompletion.ts
@@ -86,15 +86,16 @@ export class JSONCompletion {
 
 		const supportsCommitCharacters = false; //this.doesSupportsCommitCharacters(); disabled for now, waiting for new API: https://github.com/microsoft/vscode/issues/42544
 
-		const proposed: { [key: string]: CompletionItem } = {};
+		const proposed = new Map<string, CompletionItem>();
 		const collector: CompletionsCollector = {
 			add: (suggestion: CompletionItem) => {
 				let label = suggestion.label;
-				if (!proposed.hasOwnProperty(label)) {
+				const existing = proposed.get(label);
+				if (!existing) {
 					label = label.replace(/[\n]/g, '↵');
 					if (label.length > 60) {
 						const shortendedLabel = label.substr(0, 57).trim() + '...';
-						if (!proposed[shortendedLabel]) {
+						if (!proposed.has(shortendedLabel)) {
 							label = shortendedLabel;
 						}
 					}
@@ -105,10 +106,9 @@ export class JSONCompletion {
 						suggestion.commitCharacters = suggestion.kind === CompletionItemKind.Property ? propertyCommitCharacters : valueCommitCharacters;
 					}
 					suggestion.label = label;
-					proposed[label] = suggestion;
+					proposed.set(label, suggestion);
 					result.items.push(suggestion);
 				} else {
-					const existing = proposed[label];
 					if (!existing.documentation) {
 						existing.documentation = suggestion.documentation;
 					}
@@ -163,7 +163,7 @@ export class JSONCompletion {
 				const properties = node.properties;
 				properties.forEach(p => {
 					if (!currentProperty || currentProperty !== p) {
-						proposed[p.keyNode.value] = CompletionItem.create('__');
+						proposed.set(p.keyNode.value, CompletionItem.create('__'));
 					}
 				});
 				let separatorAfter = '';

--- a/src/test/completion.test.ts
+++ b/src/test/completion.test.ts
@@ -253,15 +253,20 @@ suite('JSON Completion', () => {
 		const schema: JSONSchema = {
 			type: 'object',
 			properties: {
+				'hasOwnProperty': {
+					type: 'integer',
+					description: 'hasOwnProperty'
+				},
 				'constructor': {
 					type: 'integer',
 					description: 'constructor'
-				}
+				},
 			}
 		};
 		await testCompletionsFor('{|}', schema, {
-			count: 1,
+			count: 2,
 			items: [
+				{ label: 'hasOwnProperty', documentation: 'hasOwnProperty', resultText: '{"hasOwnProperty": ${1:0}}' },
 				{ label: 'constructor', documentation: 'constructor', resultText: '{"constructor": ${1:0}}' },
 			]
 		});

--- a/src/test/completion.test.ts
+++ b/src/test/completion.test.ts
@@ -249,6 +249,25 @@ suite('JSON Completion', () => {
 
 	});
 
+	test('Complete JS inherited property with schema', async function () {
+		const schema: JSONSchema = {
+			type: 'object',
+			properties: {
+				'constructor': {
+					type: 'integer',
+					description: 'constructor'
+				}
+			}
+		};
+		await testCompletionsFor('{|}', schema, {
+			count: 1,
+			items: [
+				{ label: 'constructor', documentation: 'constructor', resultText: '{"constructor": ${1:0}}' },
+			]
+		});
+
+	});
+
 	test('Complete propertyNames', async function () {
 		const schema: JSONSchema = {
 			type: 'object',


### PR DESCRIPTION
closes #154 

I found that existing check logic does not consider JS inherited property names.