### PR TITLE
Check schema for `errorMessage` property for  "not" rule

### DIFF
--- a/src/parser/jsonParser.ts
+++ b/src/parser/jsonParser.ts
@@ -445,7 +445,7 @@ function validate(n: ASTNode | undefined, schema: JSONSchema, validationResult: 
 			if (!subValidationResult.hasProblems()) {
 				validationResult.problems.push({
 					location: { offset: node.offset, length: node.length },
-					message: l10n.t("Matches a schema that is not allowed.")
+					message: schema.errorMessage || l10n.t("Matches a schema that is not allowed.")
 				});
 			}
 			for (const ms of subMatchingSchemas.schemas) {


### PR DESCRIPTION
The error message for `notSchema` was missing a check to see if a custom errorMessage is provided in the schema by the user, so I added it. Now it is consistent with other schema rules such `allOf`, `type`