### PR TITLE
[completions] Always show details such as `Default value`

### DIFF
--- a/src/services/jsonCompletion.ts
+++ b/src/services/jsonCompletion.ts
@@ -113,6 +113,8 @@ export class JSONCompletion {
 					}
 					if (!existing.detail) {
 						existing.detail = suggestion.detail;
+						existing.labelDetails ??= {};
+						existing.labelDetails.description = suggestion.detail;
 					}
 				}
 			},
@@ -736,7 +738,7 @@ export class JSONCompletion {
 	}
 
 	private getInsertTextForPlainText(text: string): string {
-		return text.replace(/[\\\$\}]/g, '\\$&');   // escape $, \ and } 
+		return text.replace(/[\\\$\}]/g, '\\$&');   // escape $, \ and }
 	}
 
 	private getInsertTextForValue(value: any, separatorAfter: string): string {


### PR DESCRIPTION
Problem: currently we have to iterate over all completions in completion list to see which value is default, because `detail` is only shown when completion is focused. If I'm not mistaken, `detail` is used in most languages because it can be resolved later, while `labelDetails` not.

Note: When name of the label is really large, only `labelDetails.description` is truncated, so I don't see any downsides here.

![image](https://user-images.githubusercontent.com/46503702/227368773-f3619e1e-c527-42d4-a4ff-29fcfa78c406.png)
