### PR TITLE
[completion] Don't suggest duplicates when `uniqueItems: true`

### DIFF
--- a/src/test/completion.test.ts
+++ b/src/test/completion.test.ts
@@ -456,6 +456,28 @@ suite('JSON Completion', () => {
 		});
 	});
 
+	test('Complete array value with schema (uniqueItems)', async function () {
+
+		const schema: JSONSchema = {
+			type: 'object',
+			properties: {
+				'c': {
+					type: 'array',
+					uniqueItems: true,
+					items: {
+						type: 'number',
+						enum: [1, 2],
+					}
+				}
+			}
+		};
+		await testCompletionsFor('{ "c": [ 1, | ] }', schema, {
+			items: [
+				{ label: '2', resultText: '{ "c": [ 1, 2 ] }' }
+			]
+		});
+	});
+
 	test('Complete array value with schema 2', async function () {
 
 		const schema: JSONSchema = {


### PR DESCRIPTION
However, I'm still thinking of clean way to handle `boolean` and `null` completions. I wonder why for these types information is written into `types` argument, instead of collector as completion directly?

https://github.com/microsoft/vscode-json-languageservice/blob/db2fd8f86faac4c1a557e3c15d7f65e7b4612ac3/src/services/jsonCompletion.ts#L667

Edit: I see why it happens for `object` and `array` types, but I still don't understand why don't add completions for boolean and null directly in that function.