### PR TITLE
Insert missing comma or colon before completion

### DIFF
--- a/src/services/jsonCompletion.ts
+++ b/src/services/jsonCompletion.ts
@@ -15,7 +15,7 @@ import {
 	PromiseConstructor, Thenable,
 	ASTNode, ObjectASTNode, ArrayASTNode, PropertyASTNode, ClientCapabilities,
 	TextDocument,
-	CompletionItem, CompletionItemKind, CompletionList, Position, Range, TextEdit, InsertTextFormat, MarkupContent, MarkupKind
+	CompletionItem, CompletionItemKind, CompletionList, Position, Range, TextEdit, InsertTextFormat, MarkupContent, MarkupKind, StringASTNode
 } from '../jsonLanguageTypes';
 
 import * as l10n from '@vscode/l10n';
@@ -86,6 +86,27 @@ export class JSONCompletion {
 		const supportsCommitCharacters = false; //this.doesSupportsCommitCharacters(); disabled for now, waiting for new API: https://github.com/microsoft/vscode/issues/42544
 
 		const proposed = new Map<string, CompletionItem>();
+		let insertPrevEdit: { nodeAfter: ASTNode, char: string } | undefined;
+		const currentPropKey = node?.type === 'property' ? node.keyNode : undefined;
+		if (currentPropKey && offset > currentPropKey.offset + currentPropKey.length) {
+			if (this.insertColonAfterProperty(document, currentPropKey)) {
+				insertPrevEdit = {
+					nodeAfter: currentPropKey,
+					char: ':',
+				};
+			}
+		} else {
+			const prevNodeForComma = this.getPreviousNode(node, document, offset);
+			if (prevNodeForComma) {
+				const prevNodeEnd = prevNodeForComma.offset + prevNodeForComma.length;
+				if (prevNodeEnd < offset && this.evaluateSeparatorAfter(document, prevNodeEnd, offset) === ',') {
+					insertPrevEdit = {
+						nodeAfter: prevNodeForComma,
+						char: ',',
+					};
+				}
+			}
+		}
 		const collector: CompletionsCollector = {
 			add: (suggestion: CompletionItem) => {
 				let label = suggestion.label;
@@ -105,6 +126,17 @@ export class JSONCompletion {
 						suggestion.commitCharacters = suggestion.kind === CompletionItemKind.Property ? propertyCommitCharacters : valueCommitCharacters;
 					}
 					suggestion.label = label;
+					if (insertPrevEdit) {
+						const { nodeAfter } = insertPrevEdit;
+						const insertPrevPos = document.positionAt(nodeAfter.offset + nodeAfter.length);
+						suggestion.additionalTextEdits = [{
+							range: {
+								start: insertPrevPos,
+								end: insertPrevPos
+							},
+							newText: insertPrevEdit.char,
+						}];
+					}
 					proposed.set(label, suggestion);
 					result.items.push(suggestion);
 				} else {
@@ -736,7 +768,7 @@ export class JSONCompletion {
 	}
 
 	private getInsertTextForPlainText(text: string): string {
-		return text.replace(/[\\\$\}]/g, '\\$&');   // escape $, \ and } 
+		return text.replace(/[\\\$\}]/g, '\\$&');   // escape $, \ and }
 	}
 
 	private getInsertTextForValue(value: any, separatorAfter: string): string {
@@ -913,10 +945,14 @@ export class JSONCompletion {
 		return text.substring(i + 1, offset);
 	}
 
-	private evaluateSeparatorAfter(document: TextDocument, offset: number) {
+	private evaluateSeparatorAfter(document: TextDocument, offset: number, validateOffset?: number) {
 		const scanner = Json.createScanner(document.getText(), true);
 		scanner.setPosition(offset);
 		const token = scanner.scan();
+		// Insert if didn't find comma before requesting offset
+		if (validateOffset && scanner.getPosition() > validateOffset) {
+			return ',';
+		}
 		switch (token) {
 			case Json.SyntaxKind.CommaToken:
 			case Json.SyntaxKind.CloseBraceToken:
@@ -926,6 +962,13 @@ export class JSONCompletion {
 			default:
 				return ',';
 		}
+	}
+
+	private insertColonAfterProperty(document: TextDocument, node: StringASTNode) {
+		const scanner = Json.createScanner(document.getText(), true);
+		scanner.setPosition(node.offset + node.length);
+		const token = scanner.scan();
+		return token !== Json.SyntaxKind.ColonToken;
 	}
 
 	private findItemAtOffset(node: ArrayASTNode, document: TextDocument, offset: number) {
@@ -945,6 +988,39 @@ export class JSONCompletion {
 			}
 		}
 		return 0;
+	}
+
+	/** Find last item after offset */
+	private getPreviousNode(node: ASTNode | undefined , document: TextDocument, offset: number) {
+		switch (node?.type) {
+			case 'string':
+			case 'number':
+			case 'boolean':
+			case 'property':
+			case 'null': {
+				node = node?.parent?.type === 'property' ? node.parent.parent : node?.parent;
+			}
+		}
+		if (!node) {
+			return;
+		}
+		const { children } = node;
+		if (!children) {
+			return;
+		}
+		let foundIndex: number | undefined;
+		for (let i = children.length - 1; i >= 0; i--) {
+			const child = children[i];
+			if (offset > child.offset + child.length) {
+				foundIndex = i;
+				break;
+			} else if (offset >= child.offset) {
+				foundIndex = i - 1;
+				break;
+			}
+		}
+		const previousNode = foundIndex !== undefined ? children[foundIndex] : undefined;
+		return previousNode?.type === 'property' ? previousNode.valueNode : previousNode;
 	}
 
 	private isInComment(document: TextDocument, start: number, offset: number) {


### PR DESCRIPTION
Inspired by https://github.com/microsoft/TypeScript/pull/52899
Fixes https://github.com/microsoft/vscode/issues/69545 (but I don't know what to do with *when `"` is typed)

Though when I just implemented it, I was thinking of why do we need "insert missing colon" behavior: if property has suggestions `:` will be added as insert text anyway (but not always e.g. doesn't work with `oneOf`). But if property doesn't have suggestions, there is no way to trigger such behavior. So I think we should make property completions to always include `:` as insert case (there are no shorthands in JSON 😃)