### PR TITLE
Added function to register and clear external schema in the language service Interface

### DIFF
--- a/src/jsonLanguageService.ts
+++ b/src/jsonLanguageService.ts
@@ -10,7 +10,7 @@ import { JSONValidation } from './services/jsonValidation';
 import { JSONDocumentSymbols } from './services/jsonDocumentSymbols';
 import { parse as parseJSON, newJSONDocument } from './parser/jsonParser';
 import { schemaContributions } from './services/configuration';
-import { JSONSchemaService } from './services/jsonSchemaService';
+import { ISchemaHandle, JSONSchemaService } from './services/jsonSchemaService';
 import { getFoldingRanges } from './services/jsonFolding';
 import { getSelectionRanges } from './services/jsonSelectionRanges';
 import { sort } from './utils/sort';
@@ -24,7 +24,7 @@ import {
 	FoldingRange, JSONSchema, SelectionRange, FoldingRangesContext, DocumentSymbolsContext, ColorInformationContext as DocumentColorsContext,
 	TextDocument,
 	Position, CompletionItem, CompletionList, Hover, Range, SymbolInformation, Diagnostic,
-	TextEdit, FormattingOptions, DocumentSymbol, DefinitionLink, MatchingSchema, JSONLanguageStatus, SortOptions
+	TextEdit, FormattingOptions, DocumentSymbol, DefinitionLink, MatchingSchema, JSONLanguageStatus, SortOptions, SchemaConfiguration
 } from './jsonLanguageTypes';
 import { findLinks } from './services/jsonLinks';
 import { DocumentLink } from 'vscode-languageserver-types';
@@ -41,6 +41,8 @@ export interface LanguageService {
 	parseJSONDocument(document: TextDocument): JSONDocument;
 	newJSONDocument(rootNode: ASTNode, syntaxDiagnostics?: Diagnostic[]): JSONDocument;
 	resetSchema(uri: string): boolean;
+	registerExternalSchema(config: SchemaConfiguration): ISchemaHandle;
+	clearExternalSchema(uri:string): void;
 	getMatchingSchemas(document: TextDocument, jsonDocument: JSONDocument, schema?: JSONSchema): Thenable<MatchingSchema[]>;
 	getLanguageStatus(document: TextDocument, jsonDocument: JSONDocument): JSONLanguageStatus;
 	doResolve(item: CompletionItem): Thenable<CompletionItem>;
@@ -77,6 +79,8 @@ export function getLanguageService(params: LanguageServiceParams): LanguageServi
 			jsonValidation.configure(settings);
 		},
 		resetSchema: (uri: string) => jsonSchemaService.onResourceChange(uri),
+		registerExternalSchema: jsonSchemaService.registerExternalSchema.bind(jsonSchemaService),
+    	clearExternalSchema: jsonSchemaService.clearExternalSchema.bind(jsonSchemaService),
 		doValidation: jsonValidation.doValidation.bind(jsonValidation),
 		getLanguageStatus: jsonValidation.getLanguageStatus.bind(jsonValidation),
 		parseJSONDocument: (document: TextDocument) => parseJSON(document, { collectComments: true }),

--- a/src/services/jsonSchemaService.ts
+++ b/src/services/jsonSchemaService.ts
@@ -22,6 +22,11 @@ export interface IJSONSchemaService {
 	registerExternalSchema(config: SchemaConfiguration): ISchemaHandle;
 
 	/**
+	 * Clear a secific schema
+	 */
+	clearExternalSchema(uri:string): void;
+
+	/**
 	 * Clears all cached schema files
 	 */
 	clearExternalSchemas(): void;
@@ -360,6 +365,18 @@ export class JSONSchemaService implements IJSONSchemaService {
 		}
 		return config.schema ? this.addSchemaHandle(id, config.schema) : this.getOrAddSchemaHandle(id);
 	}
+
+	public clearExternalSchema(uri: string): void {
+		const normalizedUri = normalizeId(uri);
+		if (this.schemasById[normalizedUri] && this.registeredSchemasIds[normalizedUri]) {
+			delete this.schemasById[normalizedUri];
+			delete this.registeredSchemasIds[normalizedUri];
+			this.filePatternAssociations = this.filePatternAssociations.filter(
+		  		(association) => !association.getURIs().includes(normalizedUri)
+			);
+			this.cachedSchemaForResource = undefined;
+		}
+	  }
 
 	public clearExternalSchemas(): void {
 		this.schemasById = {};


### PR DESCRIPTION
This pull request adds a couple of functions to the Json Language Service Interface
- Function to register a schema
- Function to clear a previously registered schema.

Right now, if a user wants to register or clear schemas, the only way to do it is by using `configure`. Since `configure` overwrites previously registered schemas, this would require the user to maintain a list of schemas and update it accordingly and use it along with `configure`.

I noticed JSONSchema service has some utility functions that could make the above process easier. Please let me know your thoughts or if I misunderstood something and if there is currently a way to register/clean schemas without having to maintain a list of schemas.
