### PR TITLE
Add error code for `property keys must be doublequoted`

### DIFF
--- a/src/jsonLanguageTypes.ts
+++ b/src/jsonLanguageTypes.ts
@@ -60,6 +60,7 @@ export enum ErrorCode {
 	TrailingComma = 0x207,
 	DuplicateKey = 0x208,
 	CommentNotPermitted = 0x209,
+	PropertyKeysMustBeDoublequoted = 0x210,
 	SchemaResolveError = 0x300,
 	SchemaUnsupportedFeature = 0x301
 }
@@ -158,12 +159,12 @@ export interface DocumentLanguageSettings {
 	trailingCommas?: SeverityLevel;
 
 	/**
-	 * The severity of problems from schema validation. If set to 'ignore', schema validation will be skipped. If not set, 'warning' is used. 
+	 * The severity of problems from schema validation. If set to 'ignore', schema validation will be skipped. If not set, 'warning' is used.
 	 */
 	schemaValidation?: SeverityLevel;
 
 	/**
-	 * The severity of problems that occurred when resolving and loading schemas. If set to 'ignore', schema resolving problems are not reported. If not set, 'warning' is used. 
+	 * The severity of problems that occurred when resolving and loading schemas. If set to 'ignore', schema resolving problems are not reported. If not set, 'warning' is used.
 	 */
 	schemaRequest?: SeverityLevel;
 
@@ -201,7 +202,7 @@ export interface WorkspaceContextService {
 	resolveRelativePath(relativePath: string, resource: string): string;
 }
 /**
- * The schema request service is used to fetch schemas. If successful, returns a resolved promise with the content of the schema. 
+ * The schema request service is used to fetch schemas. If successful, returns a resolved promise with the content of the schema.
  * In case of an error, returns a rejected promise with a displayable error string.
  */
 export interface SchemaRequestService {
@@ -302,7 +303,7 @@ export interface ClientCapabilities {
 				 * The client supports commit characters on a completion item.
 				 */
 				commitCharactersSupport?: boolean;
-				
+
 				/**
 				 * The client has support for completion item label
 				 * details (see also `CompletionItemLabelDetails`).
@@ -373,7 +374,7 @@ export interface ColorInformationContext {
 
 export interface FormattingOptions extends LSPFormattingOptions {
 	insertFinalNewline?: boolean;
-	keepLines?: boolean;	
+	keepLines?: boolean;
 }
 
 export interface SortOptions extends LSPFormattingOptions {

--- a/src/parser/jsonParser.ts
+++ b/src/parser/jsonParser.ts
@@ -1245,7 +1245,7 @@ export function parse(textDocument: TextDocument, config?: JSONDocumentConfig): 
 		if (!key) {
 			if (scanner.getToken() === Json.SyntaxKind.Unknown) {
 				// give a more helpful error message
-				_error(l10n.t('Property keys must be doublequoted'), ErrorCode.Undefined);
+				_error(l10n.t('Property keys must be doublequoted'), ErrorCode.PropertyKeysMustBeDoublequoted);
 				const keyNode = new StringASTNodeImpl(node, scanner.getTokenOffset(), scanner.getTokenLength());
 				keyNode.value = scanner.getTokenValue();
 				key = keyNode;


### PR DESCRIPTION
Since the error message getting localized it is hard to read these error programmatically via vscode diagnostic API, so I think it would great to not use `ErrorCode.Undefined` at all (I also saw error like `Expected a JSON object, array or literal` don't have error code as well).

By the way, I see that diagnostics, created `Diagnostic.create` don't have source.