### PR TITLE
Add `node` parameter to `JSONWorkerContribution.getInfoContribution`

### DIFF
--- a/src/jsonContributions.ts
+++ b/src/jsonContributions.ts
@@ -2,10 +2,10 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { Thenable, MarkedString, CompletionItem } from './jsonLanguageService';
+import { Thenable, MarkedString, CompletionItem, ASTNode } from './jsonLanguageService';
 
 export interface JSONWorkerContribution {
-	getInfoContribution(uri: string, location: JSONPath): Thenable<MarkedString[]>;
+	getInfoContribution(uri: string, location: JSONPath, node: ASTNode): Thenable<MarkedString[]>;
 	collectPropertyCompletions(uri: string, location: JSONPath, currentWord: string, addValue: boolean, isLast: boolean, result: CompletionsCollector): Thenable<any>;
 	collectValueCompletions(uri: string, location: JSONPath, propertyKey: string, result: CompletionsCollector): Thenable<any>;
 	collectDefaultCompletions(uri: string, result: CompletionsCollector): Thenable<any>;

--- a/src/jsonContributions.ts
+++ b/src/jsonContributions.ts
@@ -5,7 +5,7 @@
 import { Thenable, MarkedString, CompletionItem, ASTNode } from './jsonLanguageService';
 
 export interface JSONWorkerContribution {
-	getInfoContribution(uri: string, location: JSONPath, node: ASTNode): Thenable<MarkedString[]>;
+	getInfoContribution(uri: string, location: JSONPath, node: ASTNode): undefined | Thenable<MarkedString[]>;
 	collectPropertyCompletions(uri: string, location: JSONPath, currentWord: string, addValue: boolean, isLast: boolean, result: CompletionsCollector): Thenable<any>;
 	collectValueCompletions(uri: string, location: JSONPath, propertyKey: string, result: CompletionsCollector): Thenable<any>;
 	collectDefaultCompletions(uri: string, result: CompletionsCollector): Thenable<any>;

--- a/src/services/jsonHover.ts
+++ b/src/services/jsonHover.ts
@@ -53,7 +53,7 @@ export class JSONHover {
 		const location = Parser.getNodePath(node);
 		for (let i = this.contributions.length - 1; i >= 0; i--) {
 			const contribution = this.contributions[i];
-			const promise = contribution.getInfoContribution(document.uri, location);
+			const promise = contribution.getInfoContribution(document.uri, location, node);
 			if (promise) {
 				return promise.then(htmlContent => createHover(htmlContent));
 			}


### PR DESCRIPTION
This should be backward compatible and allow implementers to discriminate between value and key nodes in order to only optionally return `undefined | Promise<MarkedString[]>`

Fixes #221 