### PR TITLE
Fix sorting error in case of nested trailing comma

### DIFF
--- a/src/test/sort.test.ts
+++ b/src/test/sort.test.ts
@@ -53,7 +53,7 @@ suite('Sort JSON', () => {
             '"hobbies" : ["volleyball","drawing","hiking"],',
             '"friends" : {',
             '"Marc" : {"hobbies" : ["kayaking", "mountaineering"],',
-            '"age" : 35},',
+            '"age" : 35,},',
             '"Leila" : {"hobbies" : ["watching movies",',
             '"reading books"], "age" : 32}}}'
         ].join('\n');

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -222,16 +222,17 @@ function findJsoncPropertyTree(formattedDocument: TextDocument) {
                 endLineNumber = scanner.getTokenStartLine();
                 currentContainerStack.pop();
 
-                // If we are not inside of an empty object and current property end line number has not yet been defined, define it
-                if (lastNonTriviaNonCommentToken !== SyntaxKind.OpenBraceToken
-                    && currentProperty!.endLineNumber === undefined) {
-
-                    currentProperty!.endLineNumber = endLineNumber - 1;
-                    // The current property is also the last property
-                    currentProperty!.lastProperty = true;
-                    // The last property of an object is associated with the line and index of where to add the comma, in case after sorting, it is no longer the last property
-                    currentProperty!.lineWhereToAddComma = lineOfLastNonTriviaNonCommentToken;
-                    currentProperty!.indexWhereToAddComa = endIndexOfLastNonTriviaNonCommentToken;
+                // If we are not inside of an empty object
+                if (lastNonTriviaNonCommentToken !== SyntaxKind.OpenBraceToken) {
+                    // If current property end line number has not yet been defined, define it
+                    if (currentProperty!.endLineNumber === undefined) {
+                        currentProperty!.endLineNumber = endLineNumber - 1;
+                        // The current property is also the last property
+                        currentProperty!.lastProperty = true;
+                        // The last property of an object is associated with the line and index of where to add the comma, in case after sorting, it is no longer the last property
+                        currentProperty!.lineWhereToAddComma = lineOfLastNonTriviaNonCommentToken;
+                        currentProperty!.indexWhereToAddComa = endIndexOfLastNonTriviaNonCommentToken;
+                    }
                     lastProperty = currentProperty;
                     currentProperty = currentProperty ? currentProperty.parent : undefined;
                     currentTree = currentProperty;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/178229

When encountering a nested object property with a trailing comma, such as `{ "a": { "x": 1, "y": 2, }, "c": 3 }`, the `json/sort` command would throw the following error:

```
Range#create called with invalid arguments[[object Object], [object Object], undefined, undefined]: Error: Request json/sort failed with message: Range#create called with invalid arguments[[object Object], [object Object], undefined, undefined]
```

The reason is that the sorting code's scanner failed to navigate up to the parent when `}` after the trailing comma is encountered, because the condition `currentProperty!.endLineNumber === undefined` for doing so is false if the previous non-trivia non-comment token was a comma (`endLineNumber` would have already been set when processing the comma).

As a consequence, any further properties in the parent object (like `"c"` in the above example) would be wronly considered to be part of the preceding nested object, which confuses the scanner and results in the `endLineNumber` of the last property not being set at all. This, in the end, triggers the `Range.create()` error when the sorting code attempts build a range with that undefined end line number.