### PR TITLE
Ensure parser uses errorMessage for minContains/maxContains

### DIFF
--- a/src/parser/jsonParser.ts
+++ b/src/parser/jsonParser.ts
@@ -810,13 +810,13 @@ function validate(n: ASTNode | undefined, schema: JSONSchema, validationResult: 
 			if (isNumber(schema.minContains) && containsCount < schema.minContains) {
 				validationResult.problems.push({
 					location: { offset: node.offset, length: node.length },
-					message: l10n.t('Array has too few items that match the contains contraint. Expected {0} or more.', schema.minContains)
+					message: schema.errorMessage || l10n.t('Array has too few items that match the contains contraint. Expected {0} or more.', schema.minContains)
 				});
 			}
 			if (isNumber(schema.maxContains) && containsCount > schema.maxContains) {
 				validationResult.problems.push({
 					location: { offset: node.offset, length: node.length },
-					message: l10n.t('Array has too many items that match the contains contraint. Expected {0} or less.', schema.maxContains)
+					message: schema.errorMessage || l10n.t('Array has too many items that match the contains contraint. Expected {0} or less.', schema.maxContains)
 				});
 			}
 		}


### PR DESCRIPTION
Prior to this change, the language server ignored any defined `errorMessage` when a subschema fails validation for a `contains` keyword and `minContains` is defined. The `errorMessage` was only used when `minContains` was not defined and no item in the array matched the subschema. Even if `minContains` isn't defined, the parser ignores `errorMessage` when the array contains more matching items than `maxContains` allows.

This change updates the parser to use the `errorMessage`, if defined, for any failure of the `contains` keyword, regardless of the values of `minContains` and `maxContains`.

This is useful for cases where a developer wants to define an error message indicating both what the schema expects to contain and how many times. The default error message is not very helpful in these cases, because most users won't know how to look up "the contains contraint" for whatever file they're working with.