### PR TITLE
Fix microsoft/vscode#209655: fix case-sensitive JSON sorting error

### DIFF
--- a/src/test/sort.test.ts
+++ b/src/test/sort.test.ts
@@ -1435,4 +1435,52 @@ suite('Sort JSON', () => {
 
         testSort(content, expected, formattingOptions);
     });
+
+    test('sorting a JSON object with mixed case keys', () => {
+        const content = [
+            '{',
+            '  "tEst": "tEst",',
+            '  "tesT": "tesT",',
+            '  "teSt": "teSt",',
+            '  "Test": "Test",',
+            '  "test": "test"',
+            '}'
+        ].join('\n');
+
+        const expected = [
+            '{',
+            '  "Test": "Test",',
+            '  "tEst": "tEst",',
+            '  "teSt": "teSt",',
+            '  "tesT": "tesT",',
+            '  "test": "test"',
+            '}'
+        ].join('\n');
+
+        testSort(content, expected, formattingOptions);
+    });
+
+    test('sorting an already sorted JSON object with mixed case keys', () => {
+        const content = [
+            '{',
+            '  "Test": "Test",',
+            '  "tEst": "tEst",',
+            '  "teSt": "teSt",',
+            '  "tesT": "tesT",',
+            '  "test": "test"',
+            '}'
+        ].join('\n');
+
+        const expected = [
+            '{',
+            '  "Test": "Test",',
+            '  "tEst": "tEst",',
+            '  "teSt": "teSt",',
+            '  "tesT": "tesT",',
+            '  "test": "test"',
+            '}'
+        ].join('\n');
+
+        testSort(content, expected, formattingOptions);
+    });
 });

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -376,6 +376,14 @@ function sortJsoncDocument(jsonDocument: TextDocument, propertyTree: PropertyTre
     return sortedJsonDocument;
 }
 
+function sortPropertiesCaseSensitive(properties: PropertyTree[]): void {
+    properties.sort((a, b) => {
+        const aName = a.propertyName ?? '';
+        const bName = b.propertyName ?? '';
+        return aName < bName ? -1 : aName > bName ? 1 : 0;
+    });
+}
+
 function updateSortingQueue(queue: any[], propertyTree: PropertyTree, beginningLineNumber: number) {
     if (propertyTree.childrenProperties.length === 0) {
         return;
@@ -389,6 +397,8 @@ function updateSortingQueue(queue: any[], propertyTree: PropertyTree, beginningL
         }
         const diff = minimumBeginningLineNumber - propertyTree.beginningLineNumber!;
         beginningLineNumber = beginningLineNumber + diff;
+
+        sortPropertiesCaseSensitive(propertyTree.childrenProperties);
 
         queue.push(new SortingRange(beginningLineNumber, propertyTree.childrenProperties));
 


### PR DESCRIPTION
**Summary**

This PR fixes the case-sensitive JSON sorting error described in microsoft/vscode#209655. The issue caused incorrect sorting of JSON properties with mixed-case names, like "test" and "Test".

**Details**

The problem was due to the sorting mechanism not handling case sensitivity properly, causing it to sort properties at random since it didn't know how to handle the mixed-case names. A new function was introduced to sort properties in a case-sensitive manner, ensuring accurate ordering of property names.

**Testing**

Two unit tests were added:

1. An unsorted array to verify it sorts correctly.
2. An already sorted array to confirm it remains unchanged.

These tests cover the description of the issue. 

This fix ensures that JSON properties are sorted correctly, addressing the reported issue.