### PR TITLE
Deprecate Thenable and alias to PromiseLike

### DIFF
--- a/src/example/sample.ts
+++ b/src/example/sample.ts
@@ -1,6 +1,6 @@
 
 
-import { getLanguageService, JSONSchema, SchemaRequestService, TextDocument, MatchingSchema } from '../jsonLanguageService';
+import { getLanguageService, TextDocument } from '../jsonLanguageService';
 
 async function main() {
     const jsonContentUri = 'foo://server/example.data.json';
@@ -58,4 +58,3 @@ async function main() {
 
 }
 main();
-

--- a/src/jsonContributions.ts
+++ b/src/jsonContributions.ts
@@ -2,14 +2,14 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { Thenable, MarkedString, CompletionItem } from './jsonLanguageService';
+import { MarkedString, CompletionItem } from './jsonLanguageService';
 
 export interface JSONWorkerContribution {
-	getInfoContribution(uri: string, location: JSONPath): Thenable<MarkedString[]>;
-	collectPropertyCompletions(uri: string, location: JSONPath, currentWord: string, addValue: boolean, isLast: boolean, result: CompletionsCollector): Thenable<any>;
-	collectValueCompletions(uri: string, location: JSONPath, propertyKey: string, result: CompletionsCollector): Thenable<any>;
-	collectDefaultCompletions(uri: string, result: CompletionsCollector): Thenable<any>;
-	resolveCompletion?(item: CompletionItem): Thenable<CompletionItem>;
+	getInfoContribution(uri: string, location: JSONPath): PromiseLike<MarkedString[]>;
+	collectPropertyCompletions(uri: string, location: JSONPath, currentWord: string, addValue: boolean, isLast: boolean, result: CompletionsCollector): PromiseLike<any>;
+	collectValueCompletions(uri: string, location: JSONPath, propertyKey: string, result: CompletionsCollector): PromiseLike<any>;
+	collectDefaultCompletions(uri: string, result: CompletionsCollector): PromiseLike<any>;
+	resolveCompletion?(item: CompletionItem): PromiseLike<CompletionItem>;
 }
 export type Segment = string | number;
 export type JSONPath = Segment[];

--- a/src/jsonLanguageService.ts
+++ b/src/jsonLanguageService.ts
@@ -17,7 +17,6 @@ import { sort } from './utils/sort';
 import { format } from './utils/format';
 
 import {
-	Thenable,
 	ASTNode,
 	Color, ColorInformation, ColorPresentation,
 	LanguageServiceParams, LanguageSettings, DocumentLanguageSettings,
@@ -37,23 +36,23 @@ export * from './jsonLanguageTypes';
 
 export interface LanguageService {
 	configure(settings: LanguageSettings): void;
-	doValidation(document: TextDocument, jsonDocument: JSONDocument, documentSettings?: DocumentLanguageSettings, schema?: JSONSchema): Thenable<Diagnostic[]>;
+	doValidation(document: TextDocument, jsonDocument: JSONDocument, documentSettings?: DocumentLanguageSettings, schema?: JSONSchema): PromiseLike<Diagnostic[]>;
 	parseJSONDocument(document: TextDocument): JSONDocument;
 	newJSONDocument(rootNode: ASTNode, syntaxDiagnostics?: Diagnostic[]): JSONDocument;
 	resetSchema(uri: string): boolean;
-	getMatchingSchemas(document: TextDocument, jsonDocument: JSONDocument, schema?: JSONSchema): Thenable<MatchingSchema[]>;
+	getMatchingSchemas(document: TextDocument, jsonDocument: JSONDocument, schema?: JSONSchema): PromiseLike<MatchingSchema[]>;
 	getLanguageStatus(document: TextDocument, jsonDocument: JSONDocument): JSONLanguageStatus;
-	doResolve(item: CompletionItem): Thenable<CompletionItem>;
-	doComplete(document: TextDocument, position: Position, doc: JSONDocument): Thenable<CompletionList | null>;
+	doResolve(item: CompletionItem): PromiseLike<CompletionItem>;
+	doComplete(document: TextDocument, position: Position, doc: JSONDocument): PromiseLike<CompletionList | null>;
 	findDocumentSymbols(document: TextDocument, doc: JSONDocument, context?: DocumentSymbolsContext): SymbolInformation[];
 	findDocumentSymbols2(document: TextDocument, doc: JSONDocument, context?: DocumentSymbolsContext): DocumentSymbol[];
-	findDocumentColors(document: TextDocument, doc: JSONDocument, context?: DocumentColorsContext): Thenable<ColorInformation[]>;
+	findDocumentColors(document: TextDocument, doc: JSONDocument, context?: DocumentColorsContext): PromiseLike<ColorInformation[]>;
 	getColorPresentations(document: TextDocument, doc: JSONDocument, color: Color, range: Range): ColorPresentation[];
-	doHover(document: TextDocument, position: Position, doc: JSONDocument): Thenable<Hover | null>;
+	doHover(document: TextDocument, position: Position, doc: JSONDocument): PromiseLike<Hover | null>;
 	getFoldingRanges(document: TextDocument, context?: FoldingRangesContext): FoldingRange[];
 	getSelectionRanges(document: TextDocument, positions: Position[], doc: JSONDocument): SelectionRange[];
-	findDefinition(document: TextDocument, position: Position, doc: JSONDocument): Thenable<DefinitionLink[]>;
-	findLinks(document: TextDocument, doc: JSONDocument): Thenable<DocumentLink[]>;
+	findDefinition(document: TextDocument, position: Position, doc: JSONDocument): PromiseLike<DefinitionLink[]>;
+	findLinks(document: TextDocument, doc: JSONDocument): PromiseLike<DocumentLink[]>;
 	format(document: TextDocument, range: Range, options: FormattingOptions): TextEdit[];
 	sort(document: TextDocument, options: SortOptions): TextEdit[];
 }

--- a/src/jsonLanguageTypes.ts
+++ b/src/jsonLanguageTypes.ts
@@ -206,7 +206,7 @@ export interface WorkspaceContextService {
  * In case of an error, returns a rejected promise with a displayable error string.
  */
 export interface SchemaRequestService {
-	(uri: string): Thenable<string>;
+	(uri: string): PromiseLike<string>;
 }
 
 export interface PromiseConstructor {
@@ -216,7 +216,7 @@ export interface PromiseConstructor {
 	 * a resolve callback used resolve the promise with a value or the result of another promise,
 	 * and a reject callback used to reject the promise with a provided reason or error.
 	 */
-	new <T>(executor: (resolve: (value?: T | Thenable<T | undefined>) => void, reject: (reason?: any) => void) => void): Thenable<T | undefined>;
+	new <T>(executor: (resolve: (value?: T | PromiseLike<T | undefined>) => void, reject: (reason?: any) => void) => void): PromiseLike<T | undefined>;
 
 	/**
 	 * Creates a Promise that is resolved with an array of results when all of the provided Promises
@@ -224,33 +224,29 @@ export interface PromiseConstructor {
 	 * @param values An array of Promises.
 	 * @returns A new Promise.
 	 */
-	all<T>(values: Array<T | Thenable<T>>): Thenable<T[]>;
+	all<T>(values: Array<T | PromiseLike<T>>): PromiseLike<T[]>;
 	/**
 	 * Creates a new rejected promise for the provided reason.
 	 * @param reason The reason the promise was rejected.
 	 * @returns A new rejected Promise.
 	 */
-	reject<T>(reason: any): Thenable<T>;
+	reject<T>(reason: any): PromiseLike<T>;
 
 	/**
 		 * Creates a new resolved promise for the provided value.
 		 * @param value A promise.
 		 * @returns A promise whose internal state matches the provided promise.
 		 */
-	resolve<T>(value: T | Thenable<T>): Thenable<T>;
+	resolve<T>(value: T | PromiseLike<T>): PromiseLike<T>;
 
 }
 
-export interface Thenable<R> {
-	/**
-	* Attaches callbacks for the resolution and/or rejection of the Promise.
-	* @param onfulfilled The callback to execute when the Promise is resolved.
-	* @param onrejected The callback to execute when the Promise is rejected.
-	* @returns A Promise for the completion of which ever callback is executed.
-	*/
-	then<TResult>(onfulfilled?: (value: R) => TResult | Thenable<TResult>, onrejected?: (reason: any) => TResult | Thenable<TResult>): Thenable<TResult>;
-	then<TResult>(onfulfilled?: (value: R) => TResult | Thenable<TResult>, onrejected?: (reason: any) => void): Thenable<TResult>;
-}
+/**
+ * A deprecated alias of {@link PromiseLike}
+ * 
+ * @deprecated
+ */
+export interface Thenable<R> extends PromiseLike<R> {}
 
 export interface LanguageServiceParams {
 	/**

--- a/src/services/jsonCompletion.ts
+++ b/src/services/jsonCompletion.ts
@@ -12,7 +12,7 @@ import { stringifyObject } from '../utils/json';
 import { endsWith, extendedRegExp } from '../utils/strings';
 import { isDefined } from '../utils/objects';
 import {
-	PromiseConstructor, Thenable,
+	PromiseConstructor,
 	ASTNode, ObjectASTNode, ArrayASTNode, PropertyASTNode, ClientCapabilities,
 	TextDocument,
 	CompletionItem, CompletionItemKind, CompletionList, Position, Range, TextEdit, InsertTextFormat, MarkupContent, MarkupKind
@@ -36,7 +36,7 @@ export class JSONCompletion {
 		private clientCapabilities: ClientCapabilities = {}) {
 	}
 
-	public doResolve(item: CompletionItem): Thenable<CompletionItem> {
+	public doResolve(item: CompletionItem): PromiseLike<CompletionItem> {
 		for (let i = this.contributions.length - 1; i >= 0; i--) {
 			const resolveCompletion = this.contributions[i].resolveCompletion;
 			if (resolveCompletion) {
@@ -49,7 +49,7 @@ export class JSONCompletion {
 		return this.promiseConstructor.resolve(item);
 	}
 
-	public doComplete(document: TextDocument, position: Position, doc: Parser.JSONDocument): Thenable<CompletionList> {
+	public doComplete(document: TextDocument, position: Position, doc: Parser.JSONDocument): PromiseLike<CompletionList> {
 
 		const result: CompletionList = {
 			items: [],
@@ -130,7 +130,7 @@ export class JSONCompletion {
 		};
 
 		return this.schemaService.getSchemaForResource(document.uri, doc).then((schema) => {
-			const collectionPromises: Thenable<any>[] = [];
+			const collectionPromises: PromiseLike<any>[] = [];
 
 			let addValue = true;
 			let currentKey = '';
@@ -512,7 +512,7 @@ export class JSONCompletion {
 
 	}
 
-	private getContributedValueCompletions(doc: Parser.JSONDocument, node: ASTNode | undefined, offset: number, document: TextDocument, collector: CompletionsCollector, collectionPromises: Thenable<any>[]) {
+	private getContributedValueCompletions(doc: Parser.JSONDocument, node: ASTNode | undefined, offset: number, document: TextDocument, collector: CompletionsCollector, collectionPromises: PromiseLike<any>[]) {
 		if (!node) {
 			this.contributions.forEach((contribution) => {
 				const collectPromise = contribution.collectDefaultCompletions(document.uri, collector);

--- a/src/services/jsonDocumentSymbols.ts
+++ b/src/services/jsonDocumentSymbols.ts
@@ -9,7 +9,7 @@ import { colorFromHex } from '../utils/colors';
 import * as l10n from '@vscode/l10n';
 
 import {
-	TextDocument, Thenable, ColorInformation, ColorPresentation, Color, ASTNode, PropertyASTNode, DocumentSymbolsContext, Range, TextEdit,
+	TextDocument, ColorInformation, ColorPresentation, Color, ASTNode, PropertyASTNode, DocumentSymbolsContext, Range, TextEdit,
 	SymbolInformation, SymbolKind, DocumentSymbol, Location
 } from "../jsonLanguageTypes";
 
@@ -236,7 +236,7 @@ export class JSONDocumentSymbols {
 		return undefined;
 	}
 
-	public findDocumentColors(document: TextDocument, doc: Parser.JSONDocument, context?: DocumentSymbolsContext): Thenable<ColorInformation[]> {
+	public findDocumentColors(document: TextDocument, doc: Parser.JSONDocument, context?: DocumentSymbolsContext): PromiseLike<ColorInformation[]> {
 		return this.schemaService.getSchemaForResource(document.uri, doc).then(schema => {
 			const result: ColorInformation[] = [];
 			if (schema) {

--- a/src/services/jsonHover.ts
+++ b/src/services/jsonHover.ts
@@ -6,7 +6,7 @@
 import * as Parser from '../parser/jsonParser';
 import * as SchemaService from './jsonSchemaService';
 import { JSONWorkerContribution } from '../jsonContributions';
-import { TextDocument, PromiseConstructor, Thenable, Position, Range, Hover, MarkedString } from '../jsonLanguageTypes';
+import { TextDocument, PromiseConstructor, Position, Range, Hover, MarkedString } from '../jsonLanguageTypes';
 
 export class JSONHover {
 
@@ -20,7 +20,7 @@ export class JSONHover {
 		this.promise = promiseConstructor || Promise;
 	}
 
-	public doHover(document: TextDocument, position: Position, doc: Parser.JSONDocument): Thenable<Hover | null> {
+	public doHover(document: TextDocument, position: Position, doc: Parser.JSONDocument): PromiseLike<Hover | null> {
 
 		const offset = document.offsetAt(position);
 		let node = doc.getNodeFromOffset(offset);

--- a/src/services/jsonLinks.ts
+++ b/src/services/jsonLinks.ts
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { DocumentLink } from 'vscode-languageserver-types';
-import { TextDocument, ASTNode, PropertyASTNode, Range, Thenable } from '../jsonLanguageTypes';
+import { TextDocument, ASTNode, PropertyASTNode, Range } from '../jsonLanguageTypes';
 import { JSONDocument } from '../parser/jsonParser';
 
-export function findLinks(document: TextDocument, doc: JSONDocument): Thenable<DocumentLink[]> {
+export function findLinks(document: TextDocument, doc: JSONDocument): PromiseLike<DocumentLink[]> {
 	const links: DocumentLink[] = [];
 	doc.visit(node => {
 		if (node.type === "property" && node.keyNode.value === "$ref" && node.valueNode?.type === 'string') {

--- a/src/services/jsonValidation.ts
+++ b/src/services/jsonValidation.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { JSONSchemaService, ResolvedSchema, UnresolvedSchema } from './jsonSchemaService';
+import { JSONSchemaService, ResolvedSchema } from './jsonSchemaService';
 import { JSONDocument } from '../parser/jsonParser';
 
-import { TextDocument, ErrorCode, PromiseConstructor, Thenable, LanguageSettings, DocumentLanguageSettings, SeverityLevel, Diagnostic, DiagnosticSeverity, Range, JSONLanguageStatus } from '../jsonLanguageTypes';
+import { TextDocument, ErrorCode, PromiseConstructor, LanguageSettings, DocumentLanguageSettings, SeverityLevel, Diagnostic, DiagnosticSeverity, Range, JSONLanguageStatus } from '../jsonLanguageTypes';
 import * as l10n from '@vscode/l10n';
 import { JSONSchemaRef, JSONSchema } from '../jsonSchema';
 import { isBoolean } from '../utils/objects';
@@ -32,7 +32,7 @@ export class JSONValidation {
 		}
 	}
 
-	public doValidation(textDocument: TextDocument, jsonDocument: JSONDocument, documentSettings?: DocumentLanguageSettings, schema?: JSONSchema): Thenable<Diagnostic[]> {
+	public doValidation(textDocument: TextDocument, jsonDocument: JSONDocument, documentSettings?: DocumentLanguageSettings, schema?: JSONSchema): PromiseLike<Diagnostic[]> {
 		if (!this.validationEnabled) {
 			return this.promise.resolve([]);
 		}

--- a/src/test/documentSymbols.test.ts
+++ b/src/test/documentSymbols.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import * as JsonSchema from '../jsonSchema';
 
 import {
-	Thenable, getLanguageService,
+	getLanguageService,
 	ClientCapabilities, DocumentSymbolsContext,
 	TextDocument, Color, SymbolInformation, SymbolKind, Range, Position, TextEdit, DocumentSymbol
 } from "../jsonLanguageService";
@@ -37,7 +37,7 @@ suite('JSON Document Symbols', () => {
 		return ls.findDocumentSymbols2(document, jsonDoc, context);
 	}
 
-	function assertColors(value: string, schema: JsonSchema.JSONSchema, expectedOffsets: number[], expectedColors: Color[]): Thenable<any> {
+	function assertColors(value: string, schema: JsonSchema.JSONSchema, expectedOffsets: number[], expectedColors: Color[]): PromiseLike<any> {
 		const uri = 'test://test.json';
 		const schemaUri = "http://myschemastore/test1";
 

--- a/src/test/hover.test.ts
+++ b/src/test/hover.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert';
 
-import { Hover, Position, MarkedString, TextDocument, getLanguageService, JSONSchema, JSONWorkerContribution, LanguageServiceParams } from '../jsonLanguageService';
+import { Hover, Position, MarkedString, TextDocument, getLanguageService, JSONSchema, LanguageServiceParams } from '../jsonLanguageService';
 
 suite('JSON Hover', () => {
 

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -3,8 +3,7 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-// import { TextEdit} from 'vscode-languageserver-textdocument';
-import { createScanner, SyntaxKind, JSONScanner, FormattingOptions as JPFormattingOptions } from 'jsonc-parser';
+import { createScanner, SyntaxKind, JSONScanner } from 'jsonc-parser';
 import { TextDocument, TextEdit, FormattingOptions, Position, Range, TextDocumentContentChangeEvent, SortOptions } from '../jsonLanguageTypes';
 import { format } from './format';
 import { PropertyTree, Container } from './propertyTree';


### PR DESCRIPTION
TypeScript has a builtin type for promise-like values: `PromiseLike`. `Thenable` attempts to achieve the same result, but it has some compatibility issues.

This change aliases `Thenable` to `PromiseLike`, to make it compatible with the rest of the TypeScript ecosystem.

Additionally this deprecates `Thenable`. There is no practical use case for it, but it is confusing to communicate something other than `PromiseLike` to users. All occurrences of `Thenable` were replaced with `PromiseLike`.