### PR TITLE
feat(completion): support detail from schema

### DIFF
--- a/src/jsonSchema.ts
+++ b/src/jsonSchema.ts
@@ -85,6 +85,7 @@ export interface JSONSchema {
 	suggestSortText?: string;  // VSCode extension
 	allowComments?: boolean; // VSCode extension
 	allowTrailingCommas?: boolean; // VSCode extension
+	completionDetail?: string; // VSCode extension
 }
 
 export interface JSONSchemaMap {

--- a/src/services/jsonCompletion.ts
+++ b/src/services/jsonCompletion.ts
@@ -237,8 +237,11 @@ export class JSONCompletion {
 								insertText: this.getInsertTextForProperty(key, propertySchema, addValue, separatorAfter),
 								insertTextFormat: InsertTextFormat.Snippet,
 								filterText: this.getFilterTextForValue(key),
-								documentation: this.fromMarkup(propertySchema.markdownDescription) || propertySchema.description || '',
+								documentation: this.fromMarkup(propertySchema.markdownDescription) || propertySchema.description || ''
 							};
+							if (propertySchema.completionDetail !== undefined) {
+								proposal.detail = propertySchema.completionDetail
+							}
 							if (propertySchema.suggestSortText !== undefined) {
 								proposal.sortText = propertySchema.suggestSortText;
 							}
@@ -261,8 +264,11 @@ export class JSONCompletion {
 							insertText: this.getInsertTextForProperty(name, undefined, addValue, separatorAfter),
 							insertTextFormat: InsertTextFormat.Snippet,
 							filterText: this.getFilterTextForValue(name),
-							documentation: enumDescription || this.fromMarkup(schemaPropertyNames.markdownDescription) || schemaPropertyNames.description || '',
+							documentation: enumDescription || this.fromMarkup(schemaPropertyNames.markdownDescription) || schemaPropertyNames.description || ''
 						};
+						if (schemaPropertyNames.completionDetail !== undefined) {
+							proposal.detail = schemaPropertyNames.completionDetail
+						}
 						if (schemaPropertyNames.suggestSortText !== undefined) {
 							proposal.sortText = schemaPropertyNames.suggestSortText;
 						}

--- a/src/services/jsonCompletion.ts
+++ b/src/services/jsonCompletion.ts
@@ -240,7 +240,7 @@ export class JSONCompletion {
 								documentation: this.fromMarkup(propertySchema.markdownDescription) || propertySchema.description || ''
 							};
 							if (propertySchema.completionDetail !== undefined) {
-								proposal.detail = propertySchema.completionDetail
+								proposal.detail = propertySchema.completionDetail;
 							}
 							if (propertySchema.suggestSortText !== undefined) {
 								proposal.sortText = propertySchema.suggestSortText;
@@ -267,7 +267,7 @@ export class JSONCompletion {
 							documentation: enumDescription || this.fromMarkup(schemaPropertyNames.markdownDescription) || schemaPropertyNames.description || ''
 						};
 						if (schemaPropertyNames.completionDetail !== undefined) {
-							proposal.detail = schemaPropertyNames.completionDetail
+							proposal.detail = schemaPropertyNames.completionDetail;
 						}
 						if (schemaPropertyNames.suggestSortText !== undefined) {
 							proposal.sortText = schemaPropertyNames.suggestSortText;


### PR DESCRIPTION
This pull request adds a new `completionDetail` field to `JSONSchema` to allow the customization of the `detail` field in the collected `JSONCompletionItem` results, which would be useful in scenarios like displaying type information along with the label of the completion item.

Closes #235