### PR TITLE
Fix slow large oneof validation

### DIFF
--- a/src/parser/jsonParser.ts
+++ b/src/parser/jsonParser.ts
@@ -261,6 +261,11 @@ export class ValidationResult {
 	public mergeEnumValues(validationResult: ValidationResult): void {
 		if (!this.enumValueMatch && !validationResult.enumValueMatch && this.enumValues && validationResult.enumValues) {
 			this.enumValues = this.enumValues.concat(validationResult.enumValues);
+		}
+	}
+
+	public updateEnumMismatchProblemMessages(): void {
+		if (!this.enumValueMatch && this.enumValues) {
 			for (const error of this.problems) {
 				if (error.code === ErrorCode.EnumValueMismatch) {
 					error.message = l10n.t('Value is not accepted. Valid values: {0}.', this.enumValues.map(v => JSON.stringify(v)).join(', '));
@@ -497,6 +502,7 @@ function validate(n: ASTNode | undefined, schema: JSONSchema, validationResult: 
 				});
 			}
 			if (bestMatch) {
+				bestMatch.validationResult.updateEnumMismatchProblemMessages();
 				validationResult.merge(bestMatch.validationResult);
 				matchingSchemas.merge(bestMatch.matchingSchemas);
 			}


### PR DESCRIPTION
Fix #246

Before:

https://github.com/user-attachments/assets/977de7ae-31f7-4d70-8ed8-5717028f8492

After:

https://github.com/user-attachments/assets/861e29b8-4312-4b38-91ca-367e953801ac