### PR TITLE
feat: make newJSONDocument and JSONDocument consistent

### DIFF
--- a/src/jsonLanguageService.ts
+++ b/src/jsonLanguageService.ts
@@ -38,7 +38,7 @@ export interface LanguageService {
 	configure(settings: LanguageSettings): void;
 	doValidation(document: TextDocument, jsonDocument: JSONDocument, documentSettings?: DocumentLanguageSettings, schema?: JSONSchema): PromiseLike<Diagnostic[]>;
 	parseJSONDocument(document: TextDocument): JSONDocument;
-	newJSONDocument(rootNode: ASTNode, syntaxDiagnostics?: Diagnostic[]): JSONDocument;
+	newJSONDocument(rootNode: ASTNode | undefined, syntaxDiagnostics?: Diagnostic[], comments?: Range[]): JSONDocument;
 	resetSchema(uri: string): boolean;
 	getMatchingSchemas(document: TextDocument, jsonDocument: JSONDocument, schema?: JSONSchema): PromiseLike<MatchingSchema[]>;
 	getLanguageStatus(document: TextDocument, jsonDocument: JSONDocument): JSONLanguageStatus;
@@ -79,7 +79,7 @@ export function getLanguageService(params: LanguageServiceParams): LanguageServi
 		doValidation: jsonValidation.doValidation.bind(jsonValidation),
 		getLanguageStatus: jsonValidation.getLanguageStatus.bind(jsonValidation),
 		parseJSONDocument: (document: TextDocument) => parseJSON(document, { collectComments: true }),
-		newJSONDocument: (root: ASTNode, diagnostics: Diagnostic[]) => newJSONDocument(root, diagnostics),
+		newJSONDocument: (root: ASTNode | undefined, diagnostics?: Diagnostic[], comments?: Range[]) => newJSONDocument(root, diagnostics, comments),
 		getMatchingSchemas: jsonSchemaService.getMatchingSchemas.bind(jsonSchemaService),
 		doResolve: jsonCompletion.doResolve.bind(jsonCompletion),
 		doComplete: jsonCompletion.doComplete.bind(jsonCompletion),

--- a/src/parser/jsonParser.ts
+++ b/src/parser/jsonParser.ts
@@ -308,8 +308,8 @@ export class ValidationResult {
 
 }
 
-export function newJSONDocument(root: ASTNode, diagnostics: Diagnostic[] = []) {
-	return new JSONDocument(root, diagnostics, []);
+export function newJSONDocument(root: ASTNode | undefined, diagnostics: Diagnostic[] = [], comments: Range[] = []) {
+	return new JSONDocument(root, diagnostics, comments);
 }
 
 export function getNodeValue(node: ASTNode): any {


### PR DESCRIPTION
I'd like to implement my own JSON parser, and reuse the `newJSONDocument` from `vscode-json-languageservice`. But `newJSONDocument` signature is not consistent with internal `JSONDocument`.

There are two restrictions:
1. `newJSONDocument` doesn't allow rootNode to be `undefined`(rootNode is typed with ASTNode)
2. `newJSONDocument` doesn't accept comments(defaults to `[]` internally)

This PR updates the `newJSONDocument` signature to solve these two restrictions.
