### PR TITLE
feat: Notify Invalid RegExp Patterns

### DIFF
--- a/src/parser/jsonParser.ts
+++ b/src/parser/jsonParser.ts
@@ -704,7 +704,7 @@ function validate(n: ASTNode | undefined, schema: JSONSchema, validationResult: 
 				return;
 			}
 
-			if (!(regex?.test(node.value))) {
+			if (!(regex.test(node.value))) {
 				validationResult.problems.push({
 					location: { offset: node.offset, length: node.length },
 					message: schema.patternErrorMessage || schema.errorMessage || l10n.t('String does not match the pattern of "{0}".', schema.pattern)

--- a/src/parser/jsonParser.ts
+++ b/src/parser/jsonParser.ts
@@ -695,16 +695,7 @@ function validate(n: ASTNode | undefined, schema: JSONSchema, validationResult: 
 
 		if (isString(schema.pattern)) {
 			const regex = extendedRegExp(schema.pattern);
-			if(regex === undefined) {
-				validationResult.problems.push({
-					location: { offset: node.offset, length: node.length },
-					message: l10n.t('Invalid schema pattern "{0}".', schema.pattern)
-				});
-
-				return;
-			}
-
-			if (!(regex.test(node.value))) {
+			if (regex && !(regex.test(node.value))) {
 				validationResult.problems.push({
 					location: { offset: node.offset, length: node.length },
 					message: schema.patternErrorMessage || schema.errorMessage || l10n.t('String does not match the pattern of "{0}".', schema.pattern)

--- a/src/parser/jsonParser.ts
+++ b/src/parser/jsonParser.ts
@@ -695,6 +695,13 @@ function validate(n: ASTNode | undefined, schema: JSONSchema, validationResult: 
 
 		if (isString(schema.pattern)) {
 			const regex = extendedRegExp(schema.pattern);
+			if(regex === undefined) {
+				validationResult.problems.push({
+					location: { offset: node.offset, length: node.length },
+					message: l10n.t('Invalid schema pattern "{0}".', schema.pattern)
+				});
+			}
+
 			if (!(regex?.test(node.value))) {
 				validationResult.problems.push({
 					location: { offset: node.offset, length: node.length },

--- a/src/parser/jsonParser.ts
+++ b/src/parser/jsonParser.ts
@@ -700,6 +700,8 @@ function validate(n: ASTNode | undefined, schema: JSONSchema, validationResult: 
 					location: { offset: node.offset, length: node.length },
 					message: l10n.t('Invalid schema pattern "{0}".', schema.pattern)
 				});
+
+				return;
 			}
 
 			if (!(regex?.test(node.value))) {

--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -614,12 +614,12 @@ suite('JSON Parser', () => {
 			properties: {
 				"one": {
 					type: 'string',
-					pattern: 'invalid pattern',
+					pattern: '*+ (invalid pattern)',
 				}
 			}
 		});
 
-		assert.strictEqual(semanticErrors!.length, 1);
+		assert.strictEqual(semanticErrors!.length, 0);
 
 		semanticErrors = validate2(jsonDoc, textDoc, {
 			type: 'object',

--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -614,6 +614,18 @@ suite('JSON Parser', () => {
 			properties: {
 				"one": {
 					type: 'string',
+					pattern: 'invalid pattern',
+				}
+			}
+		});
+
+		assert.strictEqual(semanticErrors!.length, 1);
+
+		semanticErrors = validate2(jsonDoc, textDoc, {
+			type: 'object',
+			properties: {
+				"one": {
+					type: 'string',
 					pattern: '(^\\d+(\\-\\d+)?$)|(.+)',
 				}
 			}


### PR DESCRIPTION
This PR allows users to be notified when an invalid regex pattern is encountered.
This is useful if a JSON schema is published that contains patterns that are not supported by `new RegExp()`.
For example, as of time of writing, the `version` pattern for the `composer.json` schema includes a possessive quantifier (`*+`) that is not supported by JavaScript (see [composer.json schema definition](https://github.com/composer/composer/blob/053a5ed2c7ba79533327554d6ac7cc8405ff3450/res/composer-schema.json)). 



