### PR TITLE
feat: allow format range to be undefined

### DIFF
--- a/src/jsonLanguageService.ts
+++ b/src/jsonLanguageService.ts
@@ -53,7 +53,7 @@ export interface LanguageService {
 	getSelectionRanges(document: TextDocument, positions: Position[], doc: JSONDocument): SelectionRange[];
 	findDefinition(document: TextDocument, position: Position, doc: JSONDocument): PromiseLike<DefinitionLink[]>;
 	findLinks(document: TextDocument, doc: JSONDocument): PromiseLike<DocumentLink[]>;
-	format(document: TextDocument, range: Range, options: FormattingOptions): TextEdit[];
+	format(document: TextDocument, range: Range | undefined, options: FormattingOptions): TextEdit[];
 	sort(document: TextDocument, options: SortOptions): TextEdit[];
 }
 
@@ -92,7 +92,7 @@ export function getLanguageService(params: LanguageServiceParams): LanguageServi
 		getSelectionRanges,
 		findDefinition: () => Promise.resolve([]),
 		findLinks,
-		format: (document: TextDocument, range: Range, options: FormattingOptions) => format(document, options, range),
+		format: (document: TextDocument, range: Range | undefined, options: FormattingOptions) => format(document, options, range),
 		sort: (document: TextDocument, options: FormattingOptions) => sort(document, options)
 	};
 }

--- a/src/test/formatter.test.ts
+++ b/src/test/formatter.test.ts
@@ -28,7 +28,7 @@ suite('JSON Formatter', () => {
 		}
 
 		const document = TextDocument.create(uri, 'json', 0, unformatted);
-		const edits = ls.format(document, range!, { tabSize: 2, insertSpaces: insertSpaces });
+		const edits = ls.format(document, range, { tabSize: 2, insertSpaces: insertSpaces });
 		const formatted = applyEdits(document, edits);
 		assert.equal(formatted, expected);
 	}


### PR DESCRIPTION
It's a common case that we need to format the whole JSON document, but `languageService.format` didn't allow range to be undefined (Which is a valid usage defined in `src/utils/format.ts`)

This PR updates the format signature which allows the following usage to format the whole JSON document:

```ts
languageService.format(document, undefined, options)
```