### PR TITLE
feat: array value completion from contributions

### DIFF
--- a/src/services/jsonCompletion.ts
+++ b/src/services/jsonCompletion.ts
@@ -525,6 +525,30 @@ export class JSONCompletion {
 				}
 			});
 		} else {
+			if (
+				node.parent?.type === 'array' && node.parent?.parent?.type === 'property' &&
+				(node.type === 'string' || node.type === 'number' || node.type === 'boolean' || node.type === 'null')
+			) {
+				const path = Parser.getNodePath(node);
+				const location = path.slice(0, -2);
+				const propertyKey = path[path.length - 2].toString();
+				this.contributions.forEach((contribution) => {
+					const collectPromise = contribution.collectValueCompletions(document.uri, location, propertyKey, collector);
+					if (collectPromise) {
+						collectionPromises.push(collectPromise);
+					}
+				});
+			} else if (node.type === 'array' && node.parent?.type === 'property') {
+				const path = Parser.getNodePath(node);
+				const location = path.slice(0, -1);
+				const propertyKey = path[path.length - 1].toString();
+				this.contributions.forEach((contribution) => {
+					const collectPromise = contribution.collectValueCompletions(document.uri, location, propertyKey, collector);
+					if (collectPromise) {
+						collectionPromises.push(collectPromise);
+					}
+				});
+			}
 			if (node.type === 'string' || node.type === 'number' || node.type === 'boolean' || node.type === 'null') {
 				node = node.parent;
 			}

--- a/src/test/completion.test.ts
+++ b/src/test/completion.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert';
 
-import { getLanguageService, JSONSchema, TextDocument, ClientCapabilities, CompletionList, CompletionItemKind, Position, MarkupContent, TextEdit } from '../jsonLanguageService';
+import { getLanguageService, JSONSchema, TextDocument, ClientCapabilities, CompletionList, CompletionItemKind, Position, MarkupContent, TextEdit, JSONWorkerContribution } from '../jsonLanguageService';
 import { repeat } from '../utils/strings';
 import { CompletionItemLabelDetails } from 'vscode-languageserver-types';
 
@@ -55,11 +55,11 @@ const assertCompletion = function (completions: CompletionList, expected: ItemDe
 
 suite('JSON Completion', () => {
 
-	const testCompletionsFor = function (value: string, schema: JSONSchema | null, expected: { count?: number, items?: ItemDescription[] }, clientCapabilities = ClientCapabilities.LATEST): PromiseLike<void> {
+	const testCompletionsFor = function (value: string, schema: JSONSchema | null, expected: { count?: number, items?: ItemDescription[] }, clientCapabilities = ClientCapabilities.LATEST, contributions?: JSONWorkerContribution[]): PromiseLike<void> {
 		const offset = value.indexOf('|');
 		value = value.substr(0, offset) + value.substr(offset + 1);
 
-		const ls = getLanguageService({ clientCapabilities });
+		const ls = getLanguageService({ clientCapabilities, contributions });
 		if (schema) {
 			ls.configure({
 				schemas: [{
@@ -592,6 +592,45 @@ suite('JSON Completion', () => {
 				{ label: 'foo', notAvailable: true }
 			]
 		});
+	});
+
+	test('Complete array value with contribution', async function () {
+
+		const contribution: JSONWorkerContribution = {
+			async getInfoContribution(uri, location) {
+				return [];
+			},
+			collectPropertyCompletions(uri, location, currentWord, addValue, isLast, result) {
+				return Promise.resolve();
+			},
+			async collectValueCompletions(uri, location, propertyKey, result) {
+				assert.deepEqual(location, ['a']);
+				assert.deepEqual(propertyKey, 'b')
+				result.add({ label: '"x"', insertText: '"x"' });
+				result.add({ label: '"y"', insertText: '"y"' });
+			},
+			collectDefaultCompletions(uri, result) {
+				return Promise.resolve();
+			}
+		};
+		await testCompletionsFor('{ "a": { "b": [ | ] } }', null, {
+			items: [
+				{ label: '"x"', resultText: '{ "a": { "b": [ "x" ] } }' },
+				{ label: '"y"', resultText: '{ "a": { "b": [ "y" ] } }' }
+			]
+		}, ClientCapabilities.LATEST, [contribution]);
+		await testCompletionsFor('{ "a": { "b": [ "z", | ] } }', null, {
+			items: [
+				{ label: '"x"', resultText: '{ "a": { "b": [ "z", "x" ] } }' },
+				{ label: '"y"', resultText: '{ "a": { "b": [ "z", "y" ] } }' }
+			]
+		}, ClientCapabilities.LATEST, [contribution]);
+		await testCompletionsFor('{ "a": { "b": [ "z", "|" ] } }', null, {
+			items: [
+				{ label: '"x"', resultText: '{ "a": { "b": [ "z", "x" ] } }' },
+				{ label: '"y"', resultText: '{ "a": { "b": [ "z", "y" ] } }' }
+			]
+		}, ClientCapabilities.LATEST, [contribution]);
 	});
 
 


### PR DESCRIPTION
This PR enables `JSONWorkerContribution` to contribute array value completions. I originally requested this feature in #263 and have now taken a first stab at implementing it. To avoid changing the API, I reused `collectValueCompletions`, but it doesn't feel like the best fit for this use case. Another approach might be introducing something like `collectArrayCompletions`, possibly with better fitting attributes like the index the cursor is at. I'm happy to hear your thoughts and feedback!