### PR TITLE
feat: make getMatchingSchemas return keys matching propertyNames schema

### DIFF
--- a/src/parser/jsonParser.ts
+++ b/src/parser/jsonParser.ts
@@ -1095,7 +1095,7 @@ function validate(n: ASTNode | undefined, schema: JSONSchema, validationResult: 
 			for (const f of node.properties) {
 				const key = f.keyNode;
 				if (key) {
-					validate(key, propertyNames, validationResult, NoOpSchemaCollector.instance, context);
+					validate(key, propertyNames, validationResult, matchingSchemas, context);
 				}
 			}
 		}


### PR DESCRIPTION
Despite the possibility to validate a key against a schema using `propertyNames`, `LanguageService.getMatchingSchemas` doesn't return such matches.

This little change fixes that.

## Example
Given a schema like this 
````
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "definitions": {
    "id": { "type": "string", "my-custom-metadata": "foo" },
  },
  "type": "object",
  "properties": {
    "name": { "type": "string" },
    "things": {
      "type": "object",
      "propertyNames": { "$ref": "#/definitions/id" },
      "additionalProperties": { "type": "string" }
    }
  }
}
````
a json like this
```
{
    "name": "Tony",
    "things": {
        "f2617076": "hat",
        "2ae481ea": "skateboard"
    }
}
```
would produce the following matches
```
[
  ...,
  {
    node: StringASTNodeImpl {
      offset: 46,
      length: 10,
      type: 'string',
      value: 'f2617076'
    },
    schema: { type: 'string', 'my-custom-metadata': 'foo' }
  },
  {
    node: StringASTNodeImpl {
      offset: 73,
      length: 10,
      type: 'string',
      value: '2ae481ea'
    },
    schema: { type: 'string', 'my-custom-metadata': 'foo' }
  },
  ...
]
```
