### PR TITLE
Escape plain text description hover correctly

### DIFF
--- a/src/services/jsonHover.ts
+++ b/src/services/jsonHover.ts
@@ -114,10 +114,10 @@ function toMarkdown(plain: string | undefined): string | undefined;
 function toMarkdown(plain: string | undefined): string | undefined {
 	if (plain) {
 		return plain
-			.replace(/[\\`*_{}[\]()#+\-.!]/g, '\\$&') // escape markdown syntax tokens: http://daringfireball.net/projects/markdown/syntax#backslash
+			.trim()
+			.replace(/[\\`*_{}[\]()<>#+\-.!]/g, '\\$&') // escape markdown syntax tokens: http://daringfireball.net/projects/markdown/syntax#backslash
 			.replace(/([ \t]+)/g, (_match, g1) => '&nbsp;'.repeat(g1.length)) // escape spaces tabs
-			.replace(/\>/gm, '\\>') // escape angle brackets
-			.replace(/(\r\n|\r|\n)/gm, '\\\n'); // escape new lines
+			.replace(/\n/g, '\\\n'); // escape new lines
 	}
 	return undefined;
 }


### PR DESCRIPTION
This matches the behavior with the documentation shown in the autocomplete

With this schema:

```json
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "properties": {
    "test": {
      "description": "For example:\n\n<script>\n  alert(1)\n</script>\n\n    Test [1]"
    }
  }
}
```

Before:

<img width="1311" height="488" alt="image" src="https://github.com/user-attachments/assets/96a25530-48c5-468b-828f-2c7e58d2e34e" />

After:

<img width="1305" height="462" alt="image" src="https://github.com/user-attachments/assets/5573d7b0-b6a7-4260-b523-6fdbb39d2987" />

