### PR TITLE
feat: examples completion for propertyNames

### DIFF
--- a/src/services/jsonCompletion.ts
+++ b/src/services/jsonCompletion.ts
@@ -289,6 +289,11 @@ export class JSONCompletion {
 							propertyNameCompletionItem(schemaPropertyNames.enum[i], enumDescription, enumDetails, enumSortText);
 						}
 					}
+					if (schemaPropertyNames.examples) {
+						for (let i = 0; i < schemaPropertyNames.examples.length; i++) {
+							propertyNameCompletionItem(schemaPropertyNames.examples[i], undefined, undefined, undefined);
+						}
+					}
 					if (schemaPropertyNames.const) {
 						propertyNameCompletionItem(schemaPropertyNames.const, undefined, schemaPropertyNames.completionDetail, schemaPropertyNames.suggestSortText);
 					}

--- a/src/test/completion.test.ts
+++ b/src/test/completion.test.ts
@@ -333,6 +333,12 @@ suite('JSON Completion', () => {
 						enum: ['a', 'b'],
 						enumSortTexts: ['2', '1'],
 					},
+				},
+				examples: {
+					type: 'object',
+					propertyNames: {
+						examples: ['a', 'b'],
+					},
 				}
 			}
 		};
@@ -379,6 +385,12 @@ suite('JSON Completion', () => {
 			items: [
 				{ label: 'a', sortText: "2" },
 				{ label: 'b', sortText: "1" },
+			]
+		});
+		await testCompletionsFor('{"examples":{|}}', schema, {
+			items: [
+				{ label: 'a' },
+				{ label: 'b' },
 			]
 		});
 	});


### PR DESCRIPTION
This PR adds support for using `examples` defined inside a `propertyNames` schema as completion suggestions.

Currently, when a JSON Schema contains `propertyNames` with an `examples` array, the values are ignored by the language service. 

### Changes

- Extended the completion provider in `jsonCompletion.ts` to check `propertyNames.examples`.
- If `examples` is present and contains strings, they are included in the completion list as property name suggestions.
- Added a new test case to ensure that examples appear in completion results.

### Example schema

```json
{
  "type": "object",
  "propertyNames": {
    "type": "string",
    "pattern": "^[a-z]+$",
    "examples": ["username", "email", "address"]
  }
}
```

### Expected behavior

When editing a JSON file with this schema, the completion list for new property names should include `"username"`, `"email"`, and `"address"`.

<img width="515" height="166" alt="image" src="https://github.com/user-attachments/assets/5a6a3ab7-be3f-4eab-8b75-8d92c6975223" />

### Motivation

This improves usability when working with schemas that define flexible object properties but still want to provide user-friendly suggestions via `examples`.

### Notes & Future Improvements

According to the JSON Schema Validation specification ([draft-07, §10.4](https://json-schema.org/draft-07/draft-handrews-json-schema-validation-01#rfc.section.10.4)), it is RECOMMENDED that the values in `examples` are valid against the associated schema.

This PR does **not** enforce validation of `examples` against `pattern` constraints. Instead, it assumes that schema authors provide consistent examples.

As a potential future improvement, validation could be added to filter out `examples` that don’t conform to the `pattern` regular expression.
