### PR TITLE
Fix typo in completionResult variable name

### DIFF
--- a/src/example/sample.ts
+++ b/src/example/sample.ts
@@ -49,8 +49,8 @@ async function main() {
      * > ]
      */
 
-    const competionResult = await jsonLanguageService.doComplete(textDocument, { line: 2, character: 18 }, jsonDocument);
-    console.log('Completion proposals:', competionResult?.items.map(i => `${i.label}`));
+    const completionResult = await jsonLanguageService.doComplete(textDocument, { line: 2, character: 18 }, jsonDocument);
+    console.log('Completion proposals:', completionResult?.items.map(i => `${i.label}`));
 
     /*
      * Completion proposals: [ '"Ireland"', '"Iceland"' ]


### PR DESCRIPTION
This pull request makes a minor change to fix a typo in a variable name in `src/example/sample.ts`. The variable `competionResult` was renamed to `completionResult` for correctness.