### PR TITLE
Add a JRef qualification language server

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,25 @@ See [sample.ts](./src/example/sample.ts) for an example on how to use the JSON l
 
 To run the sample use `yarn sample`
 
+## JRef qualification server
+
+This repository now also includes a small JSON Reference language server for `.jref` files in
+[src/jrefLanguageServer.ts](./src/jrefLanguageServer.ts). The server is intentionally narrow in
+scope for the GSoC qualification task:
+
+- validates `.jref` files as strict JSON
+- exposes document links for `$ref` string values
+- resolves go-to-definition targets for workspace-relative JSON References
+- supports JSON Pointer fragments such as `address.jref#/city`
+
+Install dependencies and start the server with:
+
+    npm install
+    npm run jref:server
+
+The server speaks LSP over stdio, so it can be launched from a VSCode extension, `vscode-languageclient`,
+or any other LSP-compatible editor client.
+
 ## Development
 
     git clone https://github.com/microsoft/vscode-json-languageservice

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "@vscode/l10n": "^0.0.18",
         "jsonc-parser": "4.0.0-next.1",
+        "jsonpointer": "^5.0.1",
+        "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.12",
         "vscode-languageserver-types": "^3.17.5",
         "vscode-uri": "^3.1.0"
@@ -1199,6 +1201,15 @@
       "integrity": "sha512-hHbZBY6wf/jvnF9bGTJ0VN3c73ch4VEHalHBPlKVnga5hnYOPNz8RDGS2lLivA8a0HAlfCJiJ9NEbbpKz6+zgg==",
       "license": "MIT"
     },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -1599,6 +1610,37 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
@@ -2411,6 +2453,11 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-4.0.0-next.1.tgz",
       "integrity": "sha512-hHbZBY6wf/jvnF9bGTJ0VN3c73ch4VEHalHBPlKVnga5hnYOPNz8RDGS2lLivA8a0HAlfCJiJ9NEbbpKz6+zgg=="
     },
+    "jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="
+    },
     "keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2662,6 +2709,28 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="
+    },
+    "vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "requires": {
+        "vscode-languageserver-protocol": "3.17.5"
+      }
+    },
+    "vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "requires": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
       }
     },
     "vscode-languageserver-textdocument": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "6.0.0-next.1",
   "description": "Language service for JSON",
   "type": "module",
+  "bin": {
+    "jref-language-server": "./lib/esm/jrefLanguageServer.js"
+  },
   "types": "./lib/esm/jsonLanguageService.d.ts",
   "exports": {
     ".": {
@@ -29,11 +32,13 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
+    "@vscode/l10n": "^0.0.18",
     "jsonc-parser": "4.0.0-next.1",
+    "jsonpointer": "^5.0.1",
+    "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.12",
     "vscode-languageserver-types": "^3.17.5",
-    "vscode-uri": "^3.1.0",
-    "@vscode/l10n": "^0.0.18"
+    "vscode-uri": "^3.1.0"
   },
   "scripts": {
     "prepack": "npm run clean && npm run compile && npm run test && npm run remove-sourcemap-refs",
@@ -43,6 +48,7 @@
     "remove-sourcemap-refs": "node ./build/remove-sourcemap-refs.js",
     "watch": "tsc -w -p ./src",
     "pretest": "npm run compile",
+    "jref:server": "npm run compile && node ./lib/esm/jrefLanguageServer.js --stdio",
     "test": "node --test ./lib/esm/test/*.test.js",
     "posttest": "npm run lint",
     "coverage": "npx nyc -r lcov npm run test",

--- a/src/jrefLanguageServer.ts
+++ b/src/jrefLanguageServer.ts
@@ -1,0 +1,83 @@
+import {
+	createConnection,
+	DiagnosticSeverity,
+	ProposedFeatures,
+	TextDocumentSyncKind,
+	type DefinitionParams,
+	type DocumentLinkParams,
+	type InitializeParams,
+	type InitializeResult
+} from 'vscode-languageserver/node.js';
+import { TextDocuments } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import {
+	WorkspaceDocumentProvider,
+	createSyntaxDiagnostics,
+	findDefinitionTarget,
+	findDocumentLinks,
+	toLocation
+} from './jrefSupport.js';
+
+const connection = createConnection(ProposedFeatures.all);
+const documents = new TextDocuments(TextDocument);
+const openDocuments = new Map<string, TextDocument>();
+const provider = new WorkspaceDocumentProvider(openDocuments);
+
+connection.onInitialize((_params: InitializeParams): InitializeResult => ({
+	capabilities: {
+		textDocumentSync: TextDocumentSyncKind.Incremental,
+		definitionProvider: true,
+		documentLinkProvider: {
+			resolveProvider: false
+		}
+	}
+}));
+
+documents.onDidOpen((event) => {
+	openDocuments.set(event.document.uri, event.document);
+	validateDocument(event.document);
+});
+
+documents.onDidChangeContent((event) => {
+	openDocuments.set(event.document.uri, event.document);
+	validateDocument(event.document);
+});
+
+documents.onDidClose((event) => {
+	openDocuments.delete(event.document.uri);
+	connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] });
+});
+
+connection.onDefinition(async (params: DefinitionParams) => {
+	const document = documents.get(params.textDocument.uri);
+	if (!document) {
+		return null;
+	}
+
+	const target = await findDefinitionTarget(document, params.position, provider);
+	return target ? toLocation(target) : null;
+});
+
+connection.onDocumentLinks(async (params: DocumentLinkParams) => {
+	const document = documents.get(params.textDocument.uri);
+	if (!document) {
+		return [];
+	}
+
+	return findDocumentLinks(document, provider);
+});
+
+documents.listen(connection);
+connection.listen();
+
+function validateDocument(document: TextDocument): void {
+	const diagnostics = createSyntaxDiagnostics(document).map((diagnostic) => ({
+		...diagnostic,
+		severity: diagnostic.severity ?? DiagnosticSeverity.Error
+	}));
+
+	connection.sendDiagnostics({
+		uri: document.uri,
+		diagnostics
+	});
+}

--- a/src/jrefSupport.ts
+++ b/src/jrefSupport.ts
@@ -1,0 +1,268 @@
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import {
+	findNodeAtLocation,
+	findNodeAtOffset,
+	parse,
+	parseTree,
+	printParseErrorCode,
+	type Node as JsonNode,
+	type ParseError
+} from 'jsonc-parser';
+import {
+	Diagnostic,
+	DiagnosticSeverity,
+	Location,
+	Position,
+	Range,
+	type DocumentLink
+} from 'vscode-languageserver-types';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { URI } from 'vscode-uri';
+
+const require = createRequire(import.meta.url);
+const jsonpointer: typeof import('jsonpointer') = require('jsonpointer');
+
+export interface ResolvedJrefTarget {
+	readonly targetUri: string;
+	readonly targetRange: Range;
+	readonly targetSelectionRange: Range;
+}
+
+export interface DocumentProvider {
+	get(uri: string): Promise<TextDocument | undefined>;
+}
+
+export function createSyntaxDiagnostics(document: TextDocument): Diagnostic[] {
+	const errors: ParseError[] = [];
+	parseTree(document.getText(), errors, {
+		allowTrailingComma: false,
+		disallowComments: true
+	});
+
+	return errors.map((error) => ({
+		message: `Syntax error: ${printParseErrorCode(error.error)}`,
+		range: Range.create(
+			Position.create(error.startLine, error.startCharacter),
+			Position.create(error.startLine, error.startCharacter + Math.max(error.length, 1))
+		),
+		severity: DiagnosticSeverity.Error,
+		source: 'jref'
+	}));
+}
+
+export async function findDefinitionTarget(
+	document: TextDocument,
+	position: Position,
+	provider: DocumentProvider
+): Promise<ResolvedJrefTarget | null> {
+	const root = parseTree(document.getText(), [], {
+		allowTrailingComma: false,
+		disallowComments: true
+	});
+
+	if (!root) {
+		return null;
+	}
+
+	const node = findNodeAtOffset(root, document.offsetAt(position), true);
+	const refNode = getRefValueNode(node);
+	if (!refNode || typeof refNode.value !== 'string') {
+		return null;
+	}
+
+	return resolveReferenceTarget(document.uri, refNode.value, provider);
+}
+
+export async function findDocumentLinks(
+	document: TextDocument,
+	provider: DocumentProvider
+): Promise<DocumentLink[]> {
+	const root = parseTree(document.getText(), [], {
+		allowTrailingComma: false,
+		disallowComments: true
+	});
+
+	if (!root) {
+		return [];
+	}
+
+	const links: DocumentLink[] = [];
+	for (const refNode of collectRefValueNodes(root)) {
+		if (typeof refNode.value !== 'string') {
+			continue;
+		}
+
+		const target = await resolveReferenceTarget(document.uri, refNode.value, provider);
+		if (!target) {
+			continue;
+		}
+
+		links.push({
+			range: createInnerStringRange(document, refNode),
+			target: target.targetUri
+		});
+	}
+
+	return links;
+}
+
+export class WorkspaceDocumentProvider implements DocumentProvider {
+	public constructor(
+		private readonly openDocuments: Map<string, TextDocument>
+	) {}
+
+	public async get(uri: string): Promise<TextDocument | undefined> {
+		const openDocument = this.openDocuments.get(uri);
+		if (openDocument) {
+			return openDocument;
+		}
+
+		const parsed = URI.parse(uri);
+		if (parsed.scheme !== 'file') {
+			return undefined;
+		}
+
+		try {
+			const contents = await readFile(parsed.fsPath, 'utf8');
+			return TextDocument.create(uri, 'jref', 0, contents);
+		} catch {
+			return undefined;
+		}
+	}
+}
+
+function createInnerStringRange(document: TextDocument, node: JsonNode): Range {
+	return Range.create(
+		document.positionAt(node.offset + 1),
+		document.positionAt(node.offset + Math.max(node.length - 1, 1))
+	);
+}
+
+function collectRefValueNodes(root: JsonNode): JsonNode[] {
+	const nodes: JsonNode[] = [];
+
+	const visit = (node: JsonNode): void => {
+		const refNode = getRefValueNode(node);
+		if (refNode === node) {
+			nodes.push(node);
+		}
+
+		for (const child of node.children ?? []) {
+			visit(child);
+		}
+	};
+
+	visit(root);
+	return nodes;
+}
+
+function getRefValueNode(node: JsonNode | undefined): JsonNode | null {
+	if (!node || node.type !== 'string' || node.parent?.type !== 'property') {
+		return null;
+	}
+
+	const [keyNode, valueNode] = node.parent.children ?? [];
+	if (keyNode?.type !== 'string' || keyNode.value !== '$ref' || valueNode !== node) {
+		return null;
+	}
+
+	return node;
+}
+
+async function resolveReferenceTarget(
+	baseUri: string,
+	reference: string,
+	provider: DocumentProvider
+): Promise<ResolvedJrefTarget | null> {
+	let targetUrl: URL;
+	try {
+		targetUrl = new URL(reference, baseUri);
+	} catch {
+		return null;
+	}
+
+	const targetUri = targetUrl.toString();
+	const targetDocument = await provider.get(targetUriWithoutFragment(targetUri));
+	if (!targetDocument) {
+		return null;
+	}
+
+	const fragment = decodeURIComponent(targetUrl.hash.slice(1));
+	const targetRange = findTargetRange(targetDocument, fragment);
+	if (!targetRange) {
+		return null;
+	}
+
+	return {
+		targetUri,
+		targetRange,
+		targetSelectionRange: targetRange
+	};
+}
+
+function targetUriWithoutFragment(uri: string): string {
+	const parsed = URI.parse(uri);
+	return parsed.with({ fragment: '' }).toString();
+}
+
+function findTargetRange(document: TextDocument, fragment: string): Range | null {
+	if (!fragment || fragment === '#') {
+		return Range.create(Position.create(0, 0), Position.create(0, 0));
+	}
+
+	const root = parseTree(document.getText(), [], {
+		allowTrailingComma: false,
+		disallowComments: true
+	});
+	if (!root) {
+		return null;
+	}
+
+	const targetValue = safelyResolvePointer(document.getText(), fragment);
+	if (targetValue.missing) {
+		return null;
+	}
+
+	const path = pointerToPath(fragment);
+	const targetNode = findNodeAtLocation(root, path);
+	if (!targetNode) {
+		return null;
+	}
+
+	const position = document.positionAt(targetNode.offset);
+	return Range.create(position, position);
+}
+
+function safelyResolvePointer(text: string, fragment: string): { missing: boolean } {
+	try {
+		const value = parse(text, [], {
+			allowTrailingComma: false,
+			disallowComments: true
+		});
+		if (fragment === '') {
+			return { missing: false };
+		}
+
+		const resolved = jsonpointer.get(value, fragment);
+		return { missing: resolved === undefined };
+	} catch {
+		return { missing: true };
+	}
+}
+
+function pointerToPath(fragment: string): (string | number)[] {
+	if (!fragment) {
+		return [];
+	}
+
+	return fragment
+		.split('/')
+		.slice(1)
+		.map((segment) => segment.replace(/~1/g, '/').replace(/~0/g, '~'))
+		.map((segment) => (/^(0|[1-9][0-9]*)$/.test(segment) ? Number(segment) : segment));
+}
+
+export function toLocation(target: ResolvedJrefTarget): Location {
+	return Location.create(target.targetUri, target.targetRange);
+}

--- a/src/test/jrefLanguageServer.test.ts
+++ b/src/test/jrefLanguageServer.test.ts
@@ -1,0 +1,95 @@
+import * as assert from 'assert';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { suite, test } from 'node:test';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { URI } from 'vscode-uri';
+import {
+	WorkspaceDocumentProvider,
+	createSyntaxDiagnostics,
+	findDefinitionTarget,
+	findDocumentLinks
+} from '../jrefSupport.js';
+
+suite('JRef Language Server', () => {
+	test('reports syntax diagnostics for invalid JSON', () => {
+		const document = TextDocument.create('file:///person.jref', 'jref', 0, '{"name": }');
+		const diagnostics = createSyntaxDiagnostics(document);
+
+		assert.equal(diagnostics.length, 1);
+		assert.match(diagnostics[0].message, /Syntax error:/);
+	});
+
+	test('resolves cross-file references as definitions and document links', async () => {
+		const tempDirectory = await mkdtemp(join(tmpdir(), 'jref-lsp-'));
+
+		try {
+			const personPath = join(tempDirectory, 'person.jref');
+			const addressPath = join(tempDirectory, 'address.jref');
+
+			await writeFile(personPath, '{\n  "name": "Jason",\n  "address": { "$ref": "address.jref#/city" }\n}\n', 'utf8');
+			await writeFile(addressPath, '{\n  "address": "123 Fake St",\n  "city": "Nowheresville"\n}\n', 'utf8');
+
+			const personUri = URI.file(personPath).toString();
+			const addressUri = URI.file(addressPath).toString();
+			const personDocument = TextDocument.create(
+				personUri,
+				'jref',
+				0,
+				await readFile(personPath, 'utf8')
+			);
+
+			const provider = new WorkspaceDocumentProvider(new Map([[personUri, personDocument]]));
+			const referenceOffset = personDocument.getText().indexOf('address.jref#/city') + 2;
+			const target = await findDefinitionTarget(
+				personDocument,
+				personDocument.positionAt(referenceOffset),
+				provider
+			);
+			const links = await findDocumentLinks(personDocument, provider);
+
+			assert.ok(target);
+			assert.equal(target?.targetUri, `${addressUri}#/city`);
+			assert.deepEqual(target?.targetRange.start, { line: 2, character: 10 });
+			assert.equal(links.length, 1);
+			assert.equal(links[0].target, `${addressUri}#/city`);
+		} finally {
+			await rm(tempDirectory, { recursive: true, force: true });
+		}
+	});
+
+	test('ignores unresolved JSON Pointer fragments', async () => {
+		const tempDirectory = await mkdtemp(join(tmpdir(), 'jref-lsp-'));
+
+		try {
+			const personPath = join(tempDirectory, 'person.jref');
+			const addressPath = join(tempDirectory, 'address.jref');
+
+			await writeFile(personPath, '{ "address": { "$ref": "address.jref#/missing" } }', 'utf8');
+			await writeFile(addressPath, '{ "city": "Nowheresville" }', 'utf8');
+
+			const personUri = URI.file(personPath).toString();
+			const personDocument = TextDocument.create(
+				personUri,
+				'jref',
+				0,
+				await readFile(personPath, 'utf8')
+			);
+
+			const provider = new WorkspaceDocumentProvider(new Map([[personUri, personDocument]]));
+			const referenceOffset = personDocument.getText().indexOf('address.jref#/missing') + 2;
+			const target = await findDefinitionTarget(
+				personDocument,
+				personDocument.positionAt(referenceOffset),
+				provider
+			);
+			const links = await findDocumentLinks(personDocument, provider);
+
+			assert.equal(target, null);
+			assert.deepEqual(links, []);
+		} finally {
+			await rm(tempDirectory, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

This PR adds a small standalone JRef language server implementation for the GSoC 2026 qualification task.

## What’s included

- strict JSON syntax validation for `.jref` files
- document links for `$ref` string values
- go-to-definition support for workspace-relative references
- JSON Pointer fragment support such as `address.jref#/city`
- focused tests covering:
  - invalid JSON diagnostics
  - cross-file reference navigation
  - unresolved fragment handling

## Implementation notes

The server is implemented in:

- `src/jrefLanguageServer.ts`
- `src/jrefSupport.ts`

It uses established libraries instead of custom parsers/resolvers:

- `jsonc-parser` for parsing and syntax errors
- `jsonpointer` for JSON Pointer resolution
- standard URI resolution for relative `$ref` targets

## Verification

Ran successfully:

- `npm run compile`
- `npx eslint src/jrefSupport.ts src/jrefLanguageServer.ts src/test/jrefLanguageServer.test.ts`
- `node --test --experimental-test-isolation=none lib/esm/test/jrefLanguageServer.test.js`

## Scope

This is intentionally narrow and focused on the qualification task requirements:
- validate syntax
- follow `$ref` targets to another JRef document in the workspace
