### PR TITLE
fix: apply vocabulary gating to completion, hover, and document symbols

### DIFF
--- a/src/services/jsonCompletion.ts
+++ b/src/services/jsonCompletion.ts
@@ -223,7 +223,7 @@ export class JSONCompletion {
 	}
 
 	private getPropertyCompletions(schema: SchemaService.ResolvedSchema, doc: Parser.JSONDocument, node: ASTNode, addValue: boolean, separatorAfter: string, collector: CompletionsCollector): void {
-		const matchingSchemas = doc.getMatchingSchemas(schema.schema, node.offset);
+		const matchingSchemas = doc.getMatchingSchemas(schema.schema, node.offset, undefined, schema.activeVocabularies);
 		matchingSchemas.forEach((s) => {
 			if (s.node === node && !s.inverted) {
 				const schemaProperties = s.schema.properties;
@@ -451,7 +451,7 @@ export class JSONCompletion {
 		if (node && (parentKey !== undefined || node.type === 'array')) {
 			const separatorAfter = this.evaluateSeparatorAfter(document, offsetForSeparator);
 
-			const matchingSchemas = doc.getMatchingSchemas(schema.schema, node.offset, valueNode);
+			const matchingSchemas = doc.getMatchingSchemas(schema.schema, node.offset, valueNode, schema.activeVocabularies);
 			for (const s of matchingSchemas) {
 				if (s.node === node && !s.inverted && s.schema) {
 					if (node.type === 'array' && s.schema.items) {

--- a/src/services/jsonDocumentSymbols.ts
+++ b/src/services/jsonDocumentSymbols.ts
@@ -241,7 +241,7 @@ export class JSONDocumentSymbols {
 			const result: ColorInformation[] = [];
 			if (schema) {
 				let limit = context && typeof context.resultLimit === 'number' ? context.resultLimit : Number.MAX_VALUE;
-				const matchingSchemas = doc.getMatchingSchemas(schema.schema);
+				const matchingSchemas = doc.getMatchingSchemas(schema.schema, undefined, undefined, schema.activeVocabularies);
 				const visitedNode: { [nodeId: string]: boolean } = {};
 				for (const s of matchingSchemas) {
 					if (!s.inverted && s.schema && (s.schema.format === 'color' || s.schema.format === 'color-hex') && s.node && s.node.type === 'string') {

--- a/src/services/jsonHover.ts
+++ b/src/services/jsonHover.ts
@@ -68,7 +68,7 @@ export class JSONHover {
 			let markdownDescription: string | undefined = undefined;
 			let markdownEnumValueDescription: string | undefined = undefined, enumValue: string | undefined = undefined;
 
-			const matchingSchemas = doc.getMatchingSchemas(schema.schema, node.offset).filter((s) => s.node === node && !s.inverted).map((s) => s.schema);
+			const matchingSchemas = doc.getMatchingSchemas(schema.schema, node.offset, undefined, schema.activeVocabularies).filter((s) => s.node === node && !s.inverted).map((s) => s.schema);
 			for (const schema of matchingSchemas) {
 				title = title || schema.title;
 				markdownDescription = markdownDescription || schema.markdownDescription || toMarkdown(schema.description);

--- a/src/test/documentSymbols.test.ts
+++ b/src/test/documentSymbols.test.ts
@@ -299,4 +299,47 @@ suite('JSON Document Symbols', () => {
 		assertColorPresentations(colorFrom256RGB(77, 33, 111, 0.5), '#4d216f80');
 	});
 
+	test('Colors respects vocabulary gating on properties', async function () {
+		// The 2019-09+ $vocabulary mechanism lets a meta-schema disable whole
+		// keyword groups. Here the meta-schema declares only the core
+		// vocabulary, so `properties` (an applicator keyword) is disabled and
+		// findDocumentColors must not descend into "a"'s schema to pick up its
+		// format: 'color'.
+		const metaschemaUri = 'http://myschemastore/custom-vocab-meta';
+		const noApplicatorMetaschema = JSON.stringify({
+			$vocabulary: {
+				'https://json-schema.org/draft/2019-09/vocab/core': true
+			}
+		});
+		const localRequestService = function (uri: string): Promise<string> {
+			if (uri === metaschemaUri) {
+				return Promise.resolve(noApplicatorMetaschema);
+			}
+			return Promise.reject<string>('Resource not found');
+		};
+
+		const uri = 'test://test.json';
+		const schemaUri = 'http://myschemastore/vocab-gate-test';
+		const schema: JsonSchema.JSONSchema = {
+			$schema: metaschemaUri,
+			type: 'object',
+			properties: {
+				'a': {
+					type: 'string',
+					format: 'color'
+				}
+			}
+		};
+
+		const ls = getLanguageService({ schemaRequestService: localRequestService, clientCapabilities: ClientCapabilities.LATEST });
+		ls.configure({ schemas: [{ fileMatch: ['*.json'], uri: schemaUri, schema }] });
+
+		const content = '{ "a": "#FF00FF" }';
+		const document = TextDocument.create(uri, 'json', 0, content);
+		const jsonDoc = ls.parseJSONDocument(document);
+		const colorInfos = await ls.findDocumentColors(document, jsonDoc);
+
+		assert.deepEqual(colorInfos, []);
+	});
+
 });


### PR DESCRIPTION
Fixes #330

`JSONDocument.getMatchingSchemas()` accepts an optional `activeVocabularies` parameter that applies 2019-09+ `$vocabulary` keyword gating (via `isKeywordEnabled`). The validation path already threads this through (`jsonValidation.ts` passes `schema.activeVocabularies` to `jsonDocument.validate(...)`), but the other four callers of `getMatchingSchemas` never did, even though `ResolvedSchema` already exposes the same `activeVocabularies` field:

- `jsonCompletion.ts` (property completions and value completions)
- `jsonHover.ts`
- `jsonDocumentSymbols.ts` (`findDocumentColors`)

The result: a schema with a custom `$vocabulary` that disables certain keywords (e.g. `properties`) correctly excludes those keywords from validation diagnostics, but completion suggestions, hover text, and color/document-symbol extraction still processed them — an inconsistency between IntelliSense and validation.

## Changes
- Pass `schema.activeVocabularies` through at all four `getMatchingSchemas` call sites, matching the existing validation convention.
- Added a regression test demonstrating that `findDocumentColors` now respects a meta-schema that omits the applicator vocabulary (fails without the fix, passes with it).

## Test plan
- [x] New regression test added to `src/test/documentSymbols.test.ts`
- [x] Verified the new test fails on the unmodified call site and passes with the fix
- [x] Full relevant test suites (`documentSymbols`, `completion`, `hover`, `parser`, `vocabularies` — 173 tests) pass
- [x] `eslint` clean