### PR TITLE
Show default, examples, readOnly and writeOnly in hover

### DIFF
--- a/src/jsonSchema.ts
+++ b/src/jsonSchema.ts
@@ -52,6 +52,8 @@ export interface JSONSchema {
 	if?: JSONSchemaRef;
 	then?: JSONSchemaRef;
 	else?: JSONSchemaRef;
+	readOnly?: boolean;
+	writeOnly?: boolean;
 
 	// schema 2019-09
 	unevaluatedProperties?: boolean | JSONSchemaRef;

--- a/src/services/jsonHover.ts
+++ b/src/services/jsonHover.ts
@@ -6,7 +6,10 @@
 import * as Parser from '../parser/jsonParser.js';
 import * as SchemaService from './jsonSchemaService.js';
 import { JSONWorkerContribution } from '../jsonContributions.js';
+import { isDefined } from '../utils/objects.js';
 import { TextDocument, PromiseConstructor, Position, Range, Hover, MarkedString } from '../jsonLanguageTypes.js';
+
+import * as l10n from '@vscode/l10n';
 
 export class JSONHover {
 
@@ -67,11 +70,27 @@ export class JSONHover {
 			let title: string | undefined = undefined;
 			let markdownDescription: string | undefined = undefined;
 			let markdownEnumValueDescription: string | undefined = undefined, enumValue: string | undefined = undefined;
+			let defaultValue: any = undefined;
+			let examples: any[] | undefined = undefined;
+			let readOnly: boolean | undefined = undefined;
+			let writeOnly: boolean | undefined = undefined;
 
 			const matchingSchemas = doc.getMatchingSchemas(schema.schema, node.offset).filter((s) => s.node === node && !s.inverted).map((s) => s.schema);
 			for (const schema of matchingSchemas) {
 				title = title || schema.title;
 				markdownDescription = markdownDescription || schema.markdownDescription || toMarkdown(schema.description);
+				if (!isDefined(defaultValue)) {
+					defaultValue = schema.default;
+				}
+				if (!examples && Array.isArray(schema.examples) && schema.examples.length) {
+					examples = schema.examples;
+				}
+				if (!isDefined(readOnly)) {
+					readOnly = schema.readOnly;
+				}
+				if (!isDefined(writeOnly)) {
+					writeOnly = schema.writeOnly;
+				}
 				if (schema.enum) {
 					const idx = schema.enum.indexOf(Parser.getNodeValue(node));
 					if (schema.markdownEnumDescriptions) {
@@ -103,6 +122,30 @@ export class JSONHover {
 					result += "\n\n";
 				}
 				result += `\`${toMarkdownCodeBlock(enumValue!)}\`: ${markdownEnumValueDescription}`;
+			}
+			if (isDefined(defaultValue)) {
+				if (result.length > 0) {
+					result += "\n\n";
+				}
+				result += l10n.t('Default: {0}', `\`${toMarkdownCodeBlock(JSON.stringify(defaultValue))}\``);
+			}
+			if (examples) {
+				if (result.length > 0) {
+					result += "\n\n";
+				}
+				result += l10n.t('Examples: {0}', examples.map(e => `\`${toMarkdownCodeBlock(JSON.stringify(e))}\``).join(', '));
+			}
+			if (readOnly) {
+				if (result.length > 0) {
+					result += "\n\n";
+				}
+				result += l10n.t('Read-only');
+			}
+			if (writeOnly) {
+				if (result.length > 0) {
+					result += "\n\n";
+				}
+				result += l10n.t('Write-only');
 			}
 			return createHover([result]);
 		});

--- a/src/test/hover.test.ts
+++ b/src/test/hover.test.ts
@@ -253,4 +253,32 @@ suite('JSON Hover', () => {
 		});
 	});
 
+	test('Annotation keywords - empty examples and complex values', async function () {
+
+		const content = '{"a": 1, "b": 2}';
+		const schema: JSONSchema = {
+			type: 'object',
+			properties: {
+				'a': {
+					type: 'number',
+					description: 'A',
+					examples: []
+				},
+				'b': {
+					type: 'number',
+					default: { key: 'value' },
+					examples: [[1, 2], { x: true }]
+				}
+			}
+		};
+		// an empty examples array must not render an Examples block
+		await testComputeInfo(content, schema, { line: 0, character: 2 }).then((result) => {
+			assert.deepEqual(result.contents, ['A']);
+		});
+		// objects and arrays are rendered as JSON
+		await testComputeInfo(content, schema, { line: 0, character: 10 }).then((result) => {
+			assert.deepEqual(result.contents, ['Default: `{"key":"value"}`\n\nExamples: `[1,2]`, `{"x":true}`']);
+		});
+	});
+
 });

--- a/src/test/hover.test.ts
+++ b/src/test/hover.test.ts
@@ -210,4 +210,47 @@ suite('JSON Hover', () => {
 		assert.deepEqual(result.contents, ['test://test.json: prop1/0']);
 
 	});
+	test('Annotation keywords', async function () {
+
+		const content = '{"port": 8080, "id": "abc", "debug": false, "secret": "s"}';
+		const schema: JSONSchema = {
+			type: 'object',
+			properties: {
+				'port': {
+					type: 'integer',
+					title: 'Port',
+					description: 'TCP port to bind.',
+					default: 8080,
+					examples: [8080, 3000]
+				},
+				'id': {
+					type: 'string',
+					description: 'Assigned by the server.',
+					readOnly: true
+				},
+				'debug': {
+					type: 'boolean',
+					default: false
+				},
+				'secret': {
+					type: 'string',
+					writeOnly: true
+				}
+			}
+		};
+		await testComputeInfo(content, schema, { line: 0, character: 2 }).then((result) => {
+			assert.deepEqual(result.contents, ['Port\n\nTCP port to bind\\.\n\nDefault: `8080`\n\nExamples: `8080`, `3000`']);
+		});
+		await testComputeInfo(content, schema, { line: 0, character: 16 }).then((result) => {
+			assert.deepEqual(result.contents, ['Assigned by the server\\.\n\nRead-only']);
+		});
+		// a falsy default must still be shown
+		await testComputeInfo(content, schema, { line: 0, character: 30 }).then((result) => {
+			assert.deepEqual(result.contents, ['Default: `false`']);
+		});
+		await testComputeInfo(content, schema, { line: 0, character: 45 }).then((result) => {
+			assert.deepEqual(result.contents, ['Write-only']);
+		});
+	});
+
 });


### PR DESCRIPTION
Renders the standard JSON Schema annotation keywords `default`, `examples`, `readOnly` and `writeOnly` in hover, which previously showed only `title` and `description` (plus the VS Code enum description extensions).

As #346 notes, an author who wants examples visible on hover currently has to duplicate them into `markdownDescription`, trading a standard keyword every validator understands for one only this library reads.

### Notes

- Falsy values are handled explicitly rather than with `||`, so `"default": false` and `"default": 0` still render.
- Labels go through `l10n.t`, matching the rest of the service.
- Values are rendered with `JSON.stringify` and the existing `toMarkdownCodeBlock` helper, consistent with how `jsonParser.ts` reports `const` and `enum` values.
- `readOnly` and `writeOnly` are added to the `JSONSchema` interface; `default` and `examples` were already declared.
- Test added to `hover.test.ts`, covering all four keywords plus the falsy-default case.

Supersedes #325, which implements `default` only.

Fixes #346
