### PR TITLE
Normalize non-boolean $vocabulary values

### DIFF
--- a/src/services/jsonSchemaService.ts
+++ b/src/services/jsonSchemaService.ts
@@ -527,7 +527,8 @@ export class JSONSchemaService implements IJSONSchemaService {
 			// not whether it's in use. All listed vocabularies should be included.
 			const vocabs = new Map<string, boolean>();
 			for (const [uri, required] of Object.entries(metaschema.$vocabulary)) {
-				vocabs.set(uri, required);
+				// Normalize: a malformed meta-schema can carry non-boolean values here.
+				vocabs.set(uri, required === true);
 			}
 			return vocabs.size > 0 ? vocabs : undefined;
 		};

--- a/src/test/schema.test.ts
+++ b/src/test/schema.test.ts
@@ -3420,6 +3420,42 @@ suite('JSON Schema', () => {
 			assert.strictEqual(validation.length, 0, 'A non-boolean $vocabulary value should not enable format assertion');
 		});
 
+		test('a non-boolean $vocabulary value still activates the vocabulary', async function () {
+			// The boolean records required vs optional; it is presence in $vocabulary that
+			// activates a vocabulary. A malformed value normalizes to false (optional) and
+			// must not drop the vocabulary, so its keywords stay enabled.
+			const metaschema = {
+				$id: 'http://test/metaschema-2019-validation-malformed',
+				$vocabulary: {
+					'https://json-schema.org/draft/2019-09/vocab/core': true,
+					'https://json-schema.org/draft/2019-09/vocab/applicator': true,
+					'https://json-schema.org/draft/2019-09/vocab/validation': 'yes'
+				},
+				type: 'object'
+			};
+
+			const schema: JSONSchema = {
+				$schema: 'http://test/metaschema-2019-validation-malformed',
+				type: 'object',
+				properties: {
+					age: { minimum: 0 }
+				}
+			};
+
+			const schemaRequestService = async (uri: string): Promise<string> => {
+				if (uri === 'http://test/metaschema-2019-validation-malformed') {
+					return JSON.stringify(metaschema);
+				}
+				return '{}';
+			};
+
+			const ls = getLanguageService({ schemaRequestService });
+
+			const { textDoc, jsonDoc } = toDocument('{ "age": -1 }');
+			const validation = await ls.doValidation(textDoc, jsonDoc, {}, schema);
+			assert.strictEqual(validation.length, 1, 'validation keywords stay enabled when the vocabulary value is malformed');
+		});
+
 		test('no format vocabulary should not produce format errors', async function () {
 			const metaschema: JSONSchema = {
 				$id: 'http://test/metaschema-no-format',

--- a/src/test/schema.test.ts
+++ b/src/test/schema.test.ts
@@ -3387,6 +3387,39 @@ suite('JSON Schema', () => {
 			assert.strictEqual(validation.length, 0, 'Optional 2019-09 format vocabulary should be annotation-only');
 		});
 
+		test('2019-09 format vocabulary with a non-boolean value is treated as optional', async function () {
+			// Deliberately malformed: $vocabulary values are required to be booleans.
+			// Not typed as JSONSchema so the invalid value can be expressed.
+			const metaschema = {
+				$id: 'http://test/metaschema-2019-format-malformed',
+				$vocabulary: {
+					'https://json-schema.org/draft/2019-09/vocab/core': true,
+					'https://json-schema.org/draft/2019-09/vocab/validation': true,
+					'https://json-schema.org/draft/2019-09/vocab/format': 'yes'
+				},
+				type: 'object'
+			};
+
+			const schema: JSONSchema = {
+				$schema: 'http://test/metaschema-2019-format-malformed',
+				type: 'string',
+				format: 'email'
+			};
+
+			const schemaRequestService = async (uri: string): Promise<string> => {
+				if (uri === 'http://test/metaschema-2019-format-malformed') {
+					return JSON.stringify(metaschema);
+				}
+				return '{}';
+			};
+
+			const ls = getLanguageService({ schemaRequestService });
+
+			const { textDoc, jsonDoc } = toDocument('"not-an-email"');
+			const validation = await ls.doValidation(textDoc, jsonDoc, {}, schema);
+			assert.strictEqual(validation.length, 0, 'A non-boolean $vocabulary value should not enable format assertion');
+		});
+
 		test('no format vocabulary should not produce format errors', async function () {
 			const metaschema: JSONSchema = {
 				$id: 'http://test/metaschema-no-format',


### PR DESCRIPTION
Normalizes `$vocabulary` values with `=== true` in `extractVocabularies`, as suggested in #333.

Without it, a malformed meta-schema value reaches `isFormatAssertionEnabled`, which returns it directly:

```ts
const format201909 = activeVocabularies.get('https://json-schema.org/draft/2019-09/vocab/format');
if (format201909 !== undefined) {
    return format201909;
}
```

So a function declared to return `boolean` could return something else, and any truthy non-boolean silently flipped `format` from annotation-only to asserting.

Added a test alongside the other 2019-09 format vocabulary tests: a meta-schema declaring `'.../vocab/format': 'yes'` must not enable format assertion. It fails on `main` (1 validation error instead of 0) and passes with the change.

Fixes #333
