### PR TITLE
Show schema default values in hover

### DIFF
--- a/src/services/jsonHover.ts
+++ b/src/services/jsonHover.ts
@@ -67,11 +67,15 @@ export class JSONHover {
 			let title: string | undefined = undefined;
 			let markdownDescription: string | undefined = undefined;
 			let markdownEnumValueDescription: string | undefined = undefined, enumValue: string | undefined = undefined;
+			let defaultValue: string | undefined = undefined;
 
 			const matchingSchemas = doc.getMatchingSchemas(schema.schema, node.offset).filter((s) => s.node === node && !s.inverted).map((s) => s.schema);
 			for (const schema of matchingSchemas) {
 				title = title || schema.title;
 				markdownDescription = markdownDescription || schema.markdownDescription || toMarkdown(schema.description);
+				if (defaultValue === undefined && schema.default !== undefined) {
+					defaultValue = JSON.stringify(schema.default);
+				}
 				if (schema.enum) {
 					const idx = schema.enum.indexOf(Parser.getNodeValue(node));
 					if (schema.markdownEnumDescriptions) {
@@ -103,6 +107,12 @@ export class JSONHover {
 					result += "\n\n";
 				}
 				result += `\`${toMarkdownCodeBlock(enumValue!)}\`: ${markdownEnumValueDescription}`;
+			}
+			if (defaultValue !== undefined) {
+				if (result.length > 0) {
+					result += "\n\n";
+				}
+				result += `Default: \`${toMarkdownCodeBlock(defaultValue)}\``;
 			}
 			return createHover([result]);
 		});

--- a/src/services/jsonHover.ts
+++ b/src/services/jsonHover.ts
@@ -112,7 +112,7 @@ export class JSONHover {
 				if (result.length > 0) {
 					result += "\n\n";
 				}
-				result += `Default: \`${toMarkdownCodeBlock(defaultValue)}\``;
+				result += `Schema default: \`${toMarkdownCodeBlock(defaultValue)}\``;
 			}
 			return createHover([result]);
 		});

--- a/src/test/hover.test.ts
+++ b/src/test/hover.test.ts
@@ -184,14 +184,14 @@ suite('JSON Hover', () => {
 		for (const [key, value] of Object.entries(defaults)) {
 			const character = content.indexOf(`"${key}"`) + 1;
 			const result = await testComputeInfo(content, schema, { line: 0, character });
-			assert.deepEqual(result.contents, [`${key} description\n\nDefault: \`${JSON.stringify(value)}\``]);
+			assert.deepEqual(result.contents, [`${key} description\n\nSchema default: \`${JSON.stringify(value)}\``]);
 		}
 
 		const result = await testComputeInfo('{ "value": 1 }', {
 			type: 'object',
 			properties: { value: { default: 0 } }
 		}, { line: 0, character: 3 });
-		assert.deepEqual(result.contents, ['Default: `0`']);
+		assert.deepEqual(result.contents, ['Schema default: `0`']);
 	});
 
 	test('Multiline descriptions', async function () {

--- a/src/test/hover.test.ts
+++ b/src/test/hover.test.ts
@@ -164,6 +164,36 @@ suite('JSON Hover', () => {
 		});
 	});
 
+	test('Default values', async function () {
+		const defaults = {
+			string: 'default',
+			zero: 0,
+			false: false,
+			null: null,
+			object: { key: 'value' }
+		};
+		const content = '{ "string": "custom", "zero": 1, "false": true, "null": "custom", "object": {} }';
+		const schema: JSONSchema = {
+			type: 'object',
+			properties: Object.fromEntries(Object.entries(defaults).map(([key, value]) => [key, {
+				description: `${key} description`,
+				default: value
+			}]))
+		};
+
+		for (const [key, value] of Object.entries(defaults)) {
+			const character = content.indexOf(`"${key}"`) + 1;
+			const result = await testComputeInfo(content, schema, { line: 0, character });
+			assert.deepEqual(result.contents, [`${key} description\n\nDefault: \`${JSON.stringify(value)}\``]);
+		}
+
+		const result = await testComputeInfo('{ "value": 1 }', {
+			type: 'object',
+			properties: { value: { default: 0 } }
+		}, { line: 0, character: 3 });
+		assert.deepEqual(result.contents, ['Default: `0`']);
+	});
+
 	test('Multiline descriptions', async function () {
 		const schema: JSONSchema = {
 			type: 'object',


### PR DESCRIPTION
## Summary
- Append a schema's JSON-serialized default value to property and value hover content, labeled **Schema default** so consumers such as VS Code Settings do not confuse it with an effective value inherited through configuration scopes.
- Preserve existing title, Markdown description, and enum-value description rendering.
- Handle falsey defaults such as `0`, `false`, and `null`, along with strings and structured JSON values.

## Scope
This addresses the hover portion of #143. It intentionally does not add a diagnostic for explicitly configured default values, since pinning a default can be intentional and that warning policy needs separate design.

## Validation
- Node 22.14.0: `npm test` (5,343 tests passed; lint passed)
- Follow-up `ff790e2`: TypeScript compile, focused hover regression, ESLint, and `git diff --check`
- `git diff --check`

## AI assistance
Codex assisted with implementation and test execution. I reviewed the final diff and understand the behavior and tests.
