### PR TITLE
Preserve definitions when resolving root references

### DIFF
--- a/src/services/jsonSchemaService.ts
+++ b/src/services/jsonSchemaService.ts
@@ -641,10 +641,16 @@ export class JSONSchemaService implements IJSONSchemaService {
 			}
 		};
 
-		const merge = (target: MergedJSONSchema, section: any): void => {
+		const merge = (target: MergedJSONSchema, section: any, preserveDefinitions: boolean): void => {
 			const targetHasSiblingKeywords = hasRefSiblingKeywords(target);
 			for (const key in section) {
 				if (!section.hasOwnProperty(key) || key === 'id' || key === '$id') {
+					continue;
+				}
+
+				// Keep root definition containers when inlining a reference within that root.
+				// Replacing or merging them would remove targets or change their locations.
+				if (preserveDefinitions && (key === 'definitions' || key === '$defs') && target[key] !== undefined) {
 					continue;
 				}
 
@@ -846,7 +852,7 @@ export class JSONSchemaService implements IJSONSchemaService {
 							delete (target as any)[key];
 						}
 					}
-					merge(target, section);
+					merge(target, section, target === sourceRoot);
 				} else if (isolateExternalResource || needsScopeIsolation(section, target)) {
 					// In JSON Schema 2019-09 or greater, $ref creates a new scope when sibling
 					// keywords would otherwise change the meaning of same-object-dependent keywords
@@ -880,7 +886,7 @@ export class JSONSchemaService implements IJSONSchemaService {
 					// Create allOf with the $ref'd schema and sibling schema
 					target.allOf = [refSchema, siblingSchema];
 				} else {
-					merge(target, section);
+					merge(target, section, target === sourceRoot);
 				}
 			} else {
 				const message = l10n.t('$ref \'{0}\' in \'{1}\' can not be resolved.', refSegment || '', sourceHandle.uri)

--- a/src/test/schema.test.ts
+++ b/src/test/schema.test.ts
@@ -184,6 +184,60 @@ suite('JSON Schema', () => {
 
 	});
 
+	for (const [draft, definitionsKey] of [
+		['http://json-schema.org/draft-07/schema#', 'definitions'],
+		['https://json-schema.org/draft/2019-09/schema', '$defs'],
+		['https://json-schema.org/draft/2020-12/schema', '$defs']
+	] as const) {
+		test(`Root $ref preserves original ${definitionsKey} pointers in ${draft}`, async function () {
+			const schemaUri = 'https://example.com/schema.json';
+			const schema: JSONSchema = {
+				$schema: draft,
+				$ref: `#/${definitionsKey}/entry`,
+				[definitionsKey]: {
+					entry: {
+						type: 'object',
+						properties: {
+							shared: { $ref: `#/${definitionsKey}/shared` },
+							nested: { $ref: `#/${definitionsKey}/entry/${definitionsKey}/shared` }
+						},
+						[definitionsKey]: { shared: { type: 'number' } }
+					},
+					shared: { type: 'string' }
+				}
+			};
+			const service = new SchemaService.JSONSchemaService(newMockRequestService(), workspaceContext);
+			service.setSchemaContributions({ schemas: { [schemaUri]: schema } });
+
+			const resolved = await service.getResolvedSchema(schemaUri);
+			assert.deepStrictEqual(resolved?.errors, []);
+			assert.deepStrictEqual(resolved?.schema.properties?.shared, { type: 'string' });
+			assert.deepStrictEqual(resolved?.schema.properties?.nested, { type: 'number' });
+			assert.strictEqual(await service.getResolvedSchema(schemaUri), resolved);
+		});
+
+		test(`Root $ref does not relocate nested ${definitionsKey} in ${draft}`, async function () {
+			const schemaUri = 'https://example.com/schema.json';
+			const schema: JSONSchema = {
+				$schema: draft,
+				$ref: `#/${definitionsKey}/entry`,
+				[definitionsKey]: {
+					entry: {
+						type: 'object',
+						properties: { value: { $ref: `#/${definitionsKey}/nestedOnly` } },
+						[definitionsKey]: { nestedOnly: { type: 'null' } }
+					}
+				}
+			};
+			const service = new SchemaService.JSONSchemaService(newMockRequestService(), workspaceContext);
+			service.setSchemaContributions({ schemas: { [schemaUri]: schema } });
+
+			const resolved = await service.getResolvedSchema(schemaUri);
+			assert.strictEqual(resolved?.errors.length, 1);
+			assertInMessage(resolved!.errors[0].message, `/${definitionsKey}/nestedOnly`);
+		});
+	}
+
 	test('Resolving $refs 2', async function () {
 		const service = new SchemaService.JSONSchemaService(newMockRequestService(), workspaceContext);
 		service.setSchemaContributions({


### PR DESCRIPTION
Fixes #355.

Preserve the root's existing `definitions` and `$defs` containers when inlining a reference from that same root. Replacing or combining those containers can remove valid JSON Pointer targets, overwrite same-named definitions, or make nested-only definitions appear at invalid root paths. External-resource merging is unchanged.

Adds six regression cases across draft-07, 2019-09, and 2020-12, covering valid nested pointers, same-named definitions, rejected relocated pointers, and cached resolution. All six fail before the fix.

Validation: `npm test` on Node 22.23.2, matching the repository's Node 22 CI configuration. All 5,352 tests and 9 lint checks passed; TypeScript compilation passed.
