### PR TITLE
fix: resolve pre-2019-09 sibling $refs against the referencing document's base URI

### DIFF
--- a/src/services/jsonSchemaService.ts
+++ b/src/services/jsonSchemaService.ts
@@ -1042,6 +1042,31 @@ export class JSONSchemaService implements IJSONSchemaService {
 
 			prefetchExternalRefs(node, parentSchema, parentHandle, new Set<JSONSchema>());
 
+			// In pre-2019-09 drafts $ref replaces its siblings, but `definitions`
+			// and `$defs` are reserved keys that survive the merge in mergeRef. The
+			// re-traversal after an external $ref merge runs with the *referenced*
+			// document's base URI, so resolve these surviving subtrees up-front with
+			// this document's base; the later re-traversal then finds their $refs
+			// already resolved and becomes a no-op for them.
+			const survivingRefKeys = ['definitions', '$defs'] as const;
+			const hasSurvivingRefSubtrees = (schema: JSONSchema): boolean =>
+				survivingRefKeys.some(key => {
+					const map = schema[key];
+					return map !== undefined && typeof map === 'object' && Object.keys(map).length > 0;
+				});
+			const traverseSurvivingRefSubtrees = (schema: JSONSchema, base: JSONSchema, baseHandle: SchemaHandle, seen: Set<JSONSchema>): PromiseLike<void> => {
+				let result: PromiseLike<void> = this.promise.resolve(undefined);
+				for (const key of survivingRefKeys) {
+					const map = schema[key];
+					if (map && typeof map === 'object') {
+						for (const child of Object.values(map)) {
+							result = result.then(() => traverseWithBaseTracking(child, base, baseHandle, false, seen));
+						}
+					}
+				}
+				return result;
+			};
+
 			// Traversal that tracks the current base schema for internal refs.
 			// When we encounter a schema with its own $id, that becomes the new base
 			// for resolving fragment refs (#...) in its descendants
@@ -1091,7 +1116,14 @@ export class JSONSchemaService implements IJSONSchemaService {
 						// Per JSON Schema spec, $ref is resolved against the current base URI.
 						const refBaseHandle = isPreDraft201909 && newBase === schema ? currentBaseHandle : newBaseHandle;
 						const continuationHandle = newBase === schema ? currentBaseHandle : newBaseHandle;
-						return resolveExternalLink(schema, segments[0], segments[1], refBaseHandle, preservesOwnBase ? newBase : undefined, preservesOwnBase ? continuationHandle : undefined).then(() => undefined);
+						const followExternalRef = (): PromiseLike<void> => resolveExternalLink(schema, segments[0], segments[1], refBaseHandle, preservesOwnBase ? newBase : undefined, preservesOwnBase ? continuationHandle : undefined).then(() => undefined);
+						if (isPreDraft201909 && hasSurvivingRefSubtrees(schema)) {
+							// Pre-2019-09: `definitions`/`$defs` survive the $ref merge but
+							// would be re-traversed with the referenced document's base
+							// URI. Resolve them first against this document's base.
+							return traverseSurvivingRefSubtrees(schema, newBase, newBaseHandle, seen).then(followExternalRef);
+						}
+						return followExternalRef();
 					} else {
 						// This is an internal reference (like "#/definitions/foo")
 						// Internal refs are resolved within the current document

--- a/src/test/schema.test.ts
+++ b/src/test/schema.test.ts
@@ -311,6 +311,49 @@ suite('JSON Schema', () => {
 		assertInMessage(diagnostics[0].message, 'string');
 	});
 
+	test('Pre-2019-09 $ref siblings in definitions resolve against the referencing document base', async function () {
+		// https://github.com/microsoft/vscode-json-languageservice/issues/354
+		// `definitions` survives the pre-2019-09 $ref merge as a reserved key; the
+		// $refs inside it must resolve against the referencing document's base URI,
+		// not the referenced document's.
+		const schemaBaseUri = 'https://example.com/schemas/entry.json';
+		const referencedSchemaUri = 'https://example.com/schemas/nested/middle.json';
+		const siblingSchemaUri = 'https://example.com/schemas/sibling.json';
+		const schemas: { [uri: string]: JSONSchema } = {
+			[schemaBaseUri]: {
+				$schema: 'http://json-schema.org/draft-07/schema#',
+				$ref: 'nested/middle.json',
+				definitions: {
+					local: {
+						$ref: 'sibling.json'
+					}
+				}
+			},
+			[referencedSchemaUri]: {
+				type: 'object',
+				properties: {
+					name: {
+						type: 'string'
+					}
+				}
+			},
+			[siblingSchemaUri]: {
+				type: 'integer'
+			}
+		};
+		const accesses: string[] = [];
+		const ls = getLanguageService({ schemaRequestService: newMockRequestService(schemas, accesses), workspaceContext });
+		ls.configure({ schemas: [{ uri: schemaBaseUri, fileMatch: ['*.json'] }] });
+		const { textDoc, jsonDoc } = toDocument('{"name": 1}', undefined, 'file:///test.json');
+
+		const diagnostics = await ls.doValidation(textDoc, jsonDoc);
+
+		assert.ok(accesses.indexOf(siblingSchemaUri) !== -1, `expected ${siblingSchemaUri} to be requested, got: ${accesses.join(', ')}`);
+		assert.ok(!accesses.some(uri => uri.endsWith('/nested/sibling.json')), `sibling.json must not resolve against nested/, got: ${accesses.join(', ')}`);
+		assert.strictEqual(diagnostics.length, 1);
+		assertInMessage(diagnostics[0].message, 'string');
+	});
+
 	test('Nested external $ref siblings keep the inherited owner resource base', async function () {
 		const schemaBaseUri = 'https://example.com/a/schema.json';
 		const referencedSchemaUri = 'https://example.com/b/schema.json';


### PR DESCRIPTION
## What

Fixes #354 — a regression bisected to 6.0.0-next.2 where relative `$ref`s inside a schema document's own `definitions` resolve against the *referenced* document's base URI instead of the *referencing* document's.

## Repro

`schemas/entry.json` (draft-07):

```json
{ "$schema": "http://json-schema.org/draft-07/schema#", "$ref": "nested/middle.json",
  "definitions": { "local": { "$ref": "sibling.json" } } }
```

Expected `sibling.json` to resolve to `schemas/sibling.json`; the request instead went to `schemas/nested/sibling.json`, producing "Unable to load schema". I reproduced this on a fresh clone of `main` (6.0.0-next.4) with a small script against the compiled lib: the request log showed `.../schemas/nested/sibling.json` followed by the ENOENT diagnostic.

## Root cause

In pre-2019-09 drafts `$ref` replaces its siblings, but `definitions`/`$defs` are reserved keys that survive the merge in `mergeRef`. After an external `$ref` merge, `resolveExternalLink` re-traverses the node via `resolveRefs(node, continuationBase ?? unresolvedSchema.schema, continuationHandle ?? referencedHandle)` — falling back to the *referenced* document's schema/handle as base. The surviving `definitions` subtree (lexically part of the referencing document) was re-traversed with that wrong base.

## Fix

In `traverseWithBaseTracking`'s external-`$ref` branch, for the pre-2019-09 case, resolve the surviving `definitions`/`$defs` subtrees first with the current (referencing document's) base, *then* follow the external `$ref`. The post-merge re-traversal then finds those `$ref`s already resolved (a no-op), while the merged content keeps the referenced document's base via the existing continuation fallback. Verified with a second repro that the referenced document's own nested refs (e.g. `nested/deep.json`) still resolve against the referenced base.

## Tests

- New regression test in `src/test/schema.test.ts`: 'Pre-2019-09 $ref siblings in definitions resolve against the referencing document base'. Verified it fails on unpatched `main` and passes with the fix.
- Full suite: `node --test ./lib/esm/test/*.test.js` — 5347 tests, all pass (includes `schema.test.ts` 146/146 and `vocabularies.test.ts`).
- `npm run lint` — 9/9 pass.