### PR TITLE
Add quick fix for trailing commas

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ and the Monaco editor.
 - _doComplete_ provides completion proposals for a given location.
 - _doResolve_ resolves a completion proposals.
 - _doHover_ provides a hover text for a given location.
+- _doCodeActions_ provides quick fixes for diagnostics at a given range.
 - _findDocumentSymbols_ provides all symbols in the given document.
 - _findDocumentColors_ provides all color symbols in the given document.
 - _getColorPresentations_ returns available color formats for a color symbol.

--- a/src/jsonLanguageService.ts
+++ b/src/jsonLanguageService.ts
@@ -6,6 +6,7 @@
 import { JSONCompletion } from './services/jsonCompletion.js';
 import { JSONHover } from './services/jsonHover.js';
 import { JSONValidation } from './services/jsonValidation.js';
+import { JSONCodeActions } from './services/jsonCodeActions.js';
 
 import { JSONDocumentSymbols } from './services/jsonDocumentSymbols.js';
 import { parse as parseJSON, newJSONDocument } from './parser/jsonParser.js';
@@ -22,7 +23,7 @@ import {
 	LanguageServiceParams, LanguageSettings, DocumentLanguageSettings,
 	FoldingRange, JSONSchema, SelectionRange, FoldingRangesContext, DocumentSymbolsContext, ColorInformationContext as DocumentColorsContext,
 	TextDocument,
-	Position, CompletionItem, CompletionList, Hover, Range, SymbolInformation, Diagnostic,
+	Position, CompletionItem, CompletionList, Hover, Range, SymbolInformation, Diagnostic, CodeAction, CodeActionContext,
 	TextEdit, FormattingOptions, DocumentSymbol, DefinitionLink, MatchingSchema, JSONLanguageStatus, SortOptions
 } from './jsonLanguageTypes.js';
 import { findLinks } from './services/jsonLinks.js';
@@ -49,6 +50,7 @@ export interface LanguageService {
 	findDocumentColors(document: TextDocument, doc: JSONDocument, context?: DocumentColorsContext): PromiseLike<ColorInformation[]>;
 	getColorPresentations(document: TextDocument, doc: JSONDocument, color: Color, range: Range): ColorPresentation[];
 	doHover(document: TextDocument, position: Position, doc: JSONDocument): PromiseLike<Hover | null>;
+	doCodeActions(document: TextDocument, range: Range, context: CodeActionContext): CodeAction[];
 	getFoldingRanges(document: TextDocument, context?: FoldingRangesContext): FoldingRange[];
 	getSelectionRanges(document: TextDocument, positions: Position[], doc: JSONDocument): SelectionRange[];
 	findDefinition(document: TextDocument, position: Position, doc: JSONDocument): PromiseLike<DefinitionLink[]>;
@@ -68,6 +70,7 @@ export function getLanguageService(params: LanguageServiceParams): LanguageServi
 	const jsonHover = new JSONHover(jsonSchemaService, params.contributions, promise);
 	const jsonDocumentSymbols = new JSONDocumentSymbols(jsonSchemaService);
 	const jsonValidation = new JSONValidation(jsonSchemaService, promise);
+	const jsonCodeActions = new JSONCodeActions();
 
 	return {
 		configure: (settings: LanguageSettings) => {
@@ -88,6 +91,7 @@ export function getLanguageService(params: LanguageServiceParams): LanguageServi
 		findDocumentColors: jsonDocumentSymbols.findDocumentColors.bind(jsonDocumentSymbols),
 		getColorPresentations: jsonDocumentSymbols.getColorPresentations.bind(jsonDocumentSymbols),
 		doHover: jsonHover.doHover.bind(jsonHover),
+		doCodeActions: jsonCodeActions.doCodeActions.bind(jsonCodeActions),
 		getFoldingRanges,
 		getSelectionRanges,
 		findDefinition: () => Promise.resolve([]),

--- a/src/services/jsonCodeActions.ts
+++ b/src/services/jsonCodeActions.ts
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as l10n from '@vscode/l10n';
+
+import {
+	CodeAction, CodeActionContext, CodeActionKind, Diagnostic, ErrorCode, Position, Range,
+	TextDocument, TextDocumentEdit, TextEdit, VersionedTextDocumentIdentifier, WorkspaceEdit
+} from '../jsonLanguageTypes.js';
+
+export class JSONCodeActions {
+
+	public doCodeActions(document: TextDocument, range: Range, context: CodeActionContext): CodeAction[] {
+		const result: CodeAction[] = [];
+		for (const diagnostic of context.diagnostics) {
+			if (diagnostic.code === ErrorCode.TrailingComma && intersects(diagnostic.range, range)) {
+				this.appendRemoveTrailingCommaFix(document, diagnostic, result);
+			}
+		}
+		return result;
+	}
+
+	private appendRemoveTrailingCommaFix(document: TextDocument, diagnostic: Diagnostic, result: CodeAction[]): void {
+		if (document.getText(diagnostic.range) !== ',') {
+			return;
+		}
+
+		const edit = TextEdit.del(diagnostic.range);
+		const documentIdentifier = VersionedTextDocumentIdentifier.create(document.uri, document.version);
+		const workspaceEdit: WorkspaceEdit = {
+			documentChanges: [TextDocumentEdit.create(documentIdentifier, [edit])]
+		};
+		const action = CodeAction.create(l10n.t('Remove trailing comma'), workspaceEdit, CodeActionKind.QuickFix);
+		action.diagnostics = [diagnostic];
+		result.push(action);
+	}
+}
+
+function intersects(left: Range, right: Range): boolean {
+	return comparePositions(left.start, right.end) <= 0 && comparePositions(right.start, left.end) <= 0;
+}
+
+function comparePositions(left: Position, right: Position): number {
+	return left.line - right.line || left.character - right.character;
+}

--- a/src/test/codeActions.test.ts
+++ b/src/test/codeActions.test.ts
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { suite, test } from 'node:test';
+
+import {
+	CodeActionKind, Diagnostic, ErrorCode, Range, TextDocument, TextDocumentEdit, TextEdit,
+	getLanguageService
+} from '../jsonLanguageService.js';
+
+suite('JSON Code Actions', () => {
+
+	async function testRemoveTrailingComma(content: string, expected: string): Promise<void> {
+		const service = getLanguageService({});
+		const document = TextDocument.create('test://test/test.json', 'json', 7, content);
+		const jsonDocument = service.parseJSONDocument(document);
+		const diagnostics = await service.doValidation(document, jsonDocument);
+		const diagnostic = diagnostics.find(candidate => candidate.code === ErrorCode.TrailingComma);
+		assert.ok(diagnostic, 'Expected a trailing comma diagnostic');
+
+		const actions = service.doCodeActions(document, diagnostic.range, { diagnostics });
+		assert.strictEqual(actions.length, 1);
+		const action = actions[0];
+		assert.strictEqual(action.title, 'Remove trailing comma');
+		assert.strictEqual(action.kind, CodeActionKind.QuickFix);
+		assert.deepStrictEqual(action.diagnostics, [diagnostic]);
+		assert.ok(action.edit?.documentChanges);
+		assert.strictEqual(action.edit.documentChanges.length, 1);
+
+		const change = action.edit.documentChanges[0];
+		assert.ok(TextDocumentEdit.is(change));
+		assert.strictEqual(change.textDocument.uri, document.uri);
+		assert.strictEqual(change.textDocument.version, document.version);
+		assert.ok(change.edits.every(TextEdit.is));
+		assert.strictEqual(TextDocument.applyEdits(document, change.edits), expected);
+	}
+
+	test('removes an object trailing comma', async () => {
+		await testRemoveTrailingComma('{ "name": "value", }', '{ "name": "value" }');
+	});
+
+	test('removes an array trailing comma', async () => {
+		await testRemoveTrailingComma('[1, 2, ]', '[1, 2 ]');
+	});
+
+	test('filters diagnostics outside the requested range', async () => {
+		const service = getLanguageService({});
+		const document = TextDocument.create('test://test/test.json', 'json', 0, '{ "name": "value", }');
+		const jsonDocument = service.parseJSONDocument(document);
+		const diagnostics = await service.doValidation(document, jsonDocument);
+
+		const actions = service.doCodeActions(document, Range.create(0, 0, 0, 0), { diagnostics });
+
+		assert.deepStrictEqual(actions, []);
+	});
+
+	test('does not edit text for unrelated or stale diagnostics', () => {
+		const service = getLanguageService({});
+		const document = TextDocument.create('test://test/test.json', 'json', 0, '{ "name": "value", }');
+		const commaOffset = document.getText().indexOf(',');
+		const commaRange = Range.create(document.positionAt(commaOffset), document.positionAt(commaOffset + 1));
+		const unrelated = Diagnostic.create(commaRange, 'Comment not permitted', undefined, ErrorCode.CommentNotPermitted);
+		const stale = Diagnostic.create(Range.create(0, 2, 0, 8), 'Trailing comma', undefined, ErrorCode.TrailingComma);
+
+		assert.deepStrictEqual(service.doCodeActions(document, commaRange, { diagnostics: [unrelated] }), []);
+		assert.deepStrictEqual(service.doCodeActions(document, stale.range, { diagnostics: [stale] }), []);
+	});
+});


### PR DESCRIPTION
## Summary

- expose `LanguageService.doCodeActions` using the standard LSP `CodeAction` types already exported by the package
- offer a `quickfix` for `ErrorCode.TrailingComma` diagnostics that removes exactly the diagnosed comma through a versioned `WorkspaceEdit`
- filter diagnostics by the requested range and verify the current document text before editing, avoiding unrelated or stale diagnostic edits
- document the new API and cover object, array, metadata, range, and stale-diagnostic behavior

Fixes #119

## Testing

- `npm run compile`
- `node --test ./lib/esm/test/codeActions.test.js ./lib/esm/test/parser.test.js` (88 passed)
- `npm run lint` (9 passed)

I also ran the full test command locally. The new code-action tests pass there; the existing JSON Schema conformance suite is not compatible with my local Node v26.3 because its legacy `url.resolve` calls reject several `urn:` identifiers, so CI on the repository-supported Node version remains the full-suite check.