### PR TITLE
Apply $vocabulary gating to keywords introduced in 2019-09

### DIFF
--- a/src/parser/jsonParser.ts
+++ b/src/parser/jsonParser.ts
@@ -516,14 +516,16 @@ function validate(n: ASTNode | undefined, schema: JSONSchema, validationResult: 
 			return context.schemaDraft <= SchemaDraft.v7;
 		}
 
-		// Keywords introduced in 2019-09 (not available in draft-07 and earlier)
-		if (keywords201909.has(keyword)) {
-			return context.schemaDraft >= SchemaDraft.v2019_09;
+		// Keywords introduced in 2019-09 (not available in draft-07 and earlier).
+		// Being draft-appropriate is necessary but not sufficient: fall through
+		// so the vocabulary gate below can still switch the keyword off.
+		if (keywords201909.has(keyword) && context.schemaDraft < SchemaDraft.v2019_09) {
+			return false;
 		}
 
 		// 'prefixItems' was introduced in 2020-12
-		if (keyword === 'prefixItems') {
-			return context.schemaDraft >= SchemaDraft.v2020_12;
+		if (keyword === 'prefixItems' && context.schemaDraft < SchemaDraft.v2020_12) {
+			return false;
 		}
 
 		// Vocabulary-based filtering only applies for 2019-09+ (vocabulary is not a concept in older drafts)

--- a/src/services/vocabularies.ts
+++ b/src/services/vocabularies.ts
@@ -16,7 +16,10 @@ const vocabularyKeywords: { [uri: string]: string[] } = {
 	'https://json-schema.org/draft/2019-09/vocab/applicator': [
 		'prefixItems', 'items', 'contains', 'additionalProperties',
 		'properties', 'patternProperties', 'dependentSchemas',
-		'propertyNames', 'if', 'then', 'else', 'allOf', 'anyOf', 'oneOf', 'not'
+		'propertyNames', 'if', 'then', 'else', 'allOf', 'anyOf', 'oneOf', 'not',
+		// 2020-12 moved these two into their own `unevaluated` vocabulary; in
+		// 2019-09 they belong to applicator.
+		'unevaluatedItems', 'unevaluatedProperties'
 	],
 	'https://json-schema.org/draft/2019-09/vocab/validation': [
 		'type', 'enum', 'const', 'multipleOf', 'maximum', 'exclusiveMaximum',

--- a/src/test/schema.test.ts
+++ b/src/test/schema.test.ts
@@ -3127,6 +3127,59 @@ suite('JSON Schema', () => {
 			assert.strictEqual(validation.length, 0, 'Validation keywords should be ignored when validation vocabulary is not active');
 		});
 
+		test('a 2019-09-only keyword is gated by $vocabulary too', async function () {
+			// minContains belongs to the validation vocabulary. The draft check for
+			// keywords introduced in 2019-09 used to answer on its own, so the
+			// vocabulary gate never saw them.
+			const metaschema: JSONSchema = {
+				$id: 'http://test/metaschema-no-validation-2',
+				$vocabulary: {
+					'https://json-schema.org/draft/2019-09/vocab/core': true,
+					'https://json-schema.org/draft/2019-09/vocab/applicator': true
+					// validation vocabulary deliberately absent
+				}
+			};
+			const schema: JSONSchema = {
+				$schema: 'http://test/metaschema-no-validation-2',
+				type: 'array',
+				contains: { type: 'number' },
+				minContains: 2
+			};
+			const schemaRequestService = async (uri: string): Promise<string> =>
+				uri === 'http://test/metaschema-no-validation-2' ? JSON.stringify(metaschema) : '{}';
+
+			const ls = getLanguageService({ schemaRequestService });
+			const { textDoc, jsonDoc } = toDocument('[1]');
+			const validation = await ls.doValidation(textDoc, jsonDoc, {}, schema);
+			assert.strictEqual(validation.length, 0, 'minContains must be ignored when the validation vocabulary is absent');
+		});
+
+		test('unevaluatedProperties still applies under the 2019-09 applicator vocabulary', async function () {
+			// 2020-12 moved unevaluated* into its own vocabulary; under 2019-09 they
+			// belong to applicator. This is the regression guard for the test above.
+			const metaschema: JSONSchema = {
+				$id: 'http://test/metaschema-applicator-2019',
+				$vocabulary: {
+					'https://json-schema.org/draft/2019-09/vocab/core': true,
+					'https://json-schema.org/draft/2019-09/vocab/applicator': true,
+					'https://json-schema.org/draft/2019-09/vocab/validation': true
+				}
+			};
+			const schema: JSONSchema = {
+				$schema: 'http://test/metaschema-applicator-2019',
+				type: 'object',
+				properties: { a: { type: 'string' } },
+				unevaluatedProperties: false
+			};
+			const schemaRequestService = async (uri: string): Promise<string> =>
+				uri === 'http://test/metaschema-applicator-2019' ? JSON.stringify(metaschema) : '{}';
+
+			const ls = getLanguageService({ schemaRequestService });
+			const { textDoc, jsonDoc } = toDocument('{ "a": "x", "b": 1 }');
+			const validation = await ls.doValidation(textDoc, jsonDoc, {}, schema);
+			assert.strictEqual(validation.length, 1, 'unevaluatedProperties must still be asserted under 2019-09 applicator');
+		});
+
 		test('meta-schema with validation vocabulary should process validation keywords', async function () {
 			// Custom meta-schema with validation vocabulary
 			const metaschema: JSONSchema = {


### PR DESCRIPTION
## Problem

`enabled()` in `validate()` layers a draft check in front of the `$vocabulary` gate, but the draft checks `return` unconditionally:

```ts
if (keywords201909.has(keyword)) {
    return context.schemaDraft >= SchemaDraft.v2019_09;
}

if (keyword === 'prefixItems') {
    return context.schemaDraft >= SchemaDraft.v2020_12;
}

if (context.schemaDraft >= SchemaDraft.v2019_09 && context.activeVocabularies) {
    return isKeywordEnabled(keyword, context.activeVocabularies);   // never reached for the above
}
```

So for `dependentRequired`, `dependentSchemas`, `minContains`, `maxContains`, `unevaluatedItems`, `unevaluatedProperties` and `prefixItems`, the vocabulary gate never runs — even though `vocabularies.ts` maps every one of them to a vocabulary and clearly intends them to be gated.

A meta-schema that declares `$vocabulary` without, say, the validation vocabulary still gets `minContains` asserted. The result is a diagnostic on a document that is valid under the meta-schema it declares — a false positive rather than a missed error.

## Fix

Two parts, both required.

**1. `jsonParser.ts`** — make the draft checks narrowing rather than terminal, so a draft-appropriate keyword falls through to the vocabulary gate.

**2. `vocabularies.ts`** — record `unevaluatedItems` / `unevaluatedProperties` under the 2019-09 **applicator** vocabulary. 2020-12 split them into their own `unevaluated` vocabulary, and only that entry exists today. Without this, part 1 turns them off for every 2019-09 schema, because they belong to no 2019-09 vocabulary in the table.

## Test plan

- Added two cases to the existing `Vocabulary Support (JSON Schema 2019-09+)` suite, using its own `getLanguageService` + `doValidation` pattern:
  - a meta-schema without the validation vocabulary must ignore `minContains`
  - a 2019-09 meta-schema *with* applicator must still assert `unevaluatedProperties`
- Ran: `node --test ./lib/esm/test/*.test.js` → **5348 passing** (5346 before).
- Checked each half separately:
  - reverting only the parser change fails the first test
  - reverting only the vocabulary entry fails the second
  
  so neither half is redundant.
- Ran: `npm run lint` → clean.

## Note

`prefixItems` is listed under the 2019-09 applicator vocabulary in the table, though it only exists from 2020-12. That is harmless both before and after this change — the draft guard rejects it for 2019-09 either way — so I left it alone rather than widening the diff.