### PR TITLE
Fix sorting nested containers with trailing commas

### DIFF
--- a/src/test/sort.test.ts
+++ b/src/test/sort.test.ts
@@ -15,6 +15,68 @@ suite('Sort JSON', () => {
         assert.equal(sorted, expected);
     }
 
+    test('sorting nested containers with trailing commas', () => {
+        const content = '{"launch":{"configurations":[{"args":["exec"],}],}}';
+        const expected = [
+            '{',
+            '  "launch": {',
+            '    "configurations": [',
+            '      {',
+            '        "args": [',
+            '          "exec"',
+            '        ]',
+            '      }',
+            '    ]',
+            '  }',
+            '}'
+        ].join('\n');
+
+        testSort(content, expected, formattingOptions);
+        testSort(expected, expected, formattingOptions);
+    });
+
+    for (const [name, value, sortedValue] of [
+        ['empty object', '{}', {}],
+        ['empty array', '[]', []],
+        ['object', '{"b":2,"a":1}', { a: 1, b: 2 }],
+        ['array', '[2,1]', [2, 1]],
+        ['nested array', '[[{"b":2,"a":1}]]', [[{ a: 1, b: 2 }]]]
+    ] as const) {
+        test(`sorting a trailing comma after an ${name} with following siblings`, () => {
+            const content = `{"z":[{"z":0,"a":${value},},{"b":2}],"a":1}`;
+            const expected = JSON.stringify({ a: 1, z: [{ a: sortedValue, z: 0 }, { b: 2 }] }, null, 2);
+
+            testSort(content, expected, formattingOptions);
+            testSort(expected, expected, formattingOptions);
+        });
+    }
+
+    test('sorting nested trailing commas with comments', () => {
+        const content = [
+            '{',
+            '  "z": [{',
+            '    "z": 0,',
+            '    "a": [], // keep with a',
+            '  }], /* keep with z */',
+            '  "a": 1',
+            '}'
+        ].join('\n');
+        const expected = [
+            '{',
+            '  "a": 1,',
+            '  "z": [',
+            '    {',
+            '      "a": [], // keep with a',
+            '      "z": 0',
+            '    }',
+            '  ] /* keep with z */',
+            '}'
+        ].join('\n');
+
+        testSort(content, expected, formattingOptions);
+        testSort(expected, expected, formattingOptions);
+    });
+
     test('sorting a simple JSONC object with numeric values', () => {
         const content = [
             '{"b" : 1, "a" : 2}'

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -221,8 +221,9 @@ function findJsoncPropertyTree(formattedDocument: TextDocument) {
                 endLineNumber = scanner.getTokenStartLine();
                 currentContainerStack.pop();
 
-                // If we are not inside of an empty object
-                if (lastNonTriviaNonCommentToken !== SyntaxKind.OpenBraceToken) {
+                // A trailing comma after a container already moved back to the object itself.
+                if (lastNonTriviaNonCommentToken !== SyntaxKind.OpenBraceToken
+                    && !(lastNonTriviaNonCommentToken === SyntaxKind.CommaToken && currentProperty === currentTree)) {
                     // If current property end line number has not yet been defined, define it
                     if (currentProperty!.endLineNumber === undefined) {
                         currentProperty!.endLineNumber = endLineNumber - 1;


### PR DESCRIPTION
Sorting JSONC such as `{"launch":{"configurations":[{"args":["exec"],}],}}` throws while building the property tree. A comma after a container has already moved the current property back to its containing object, but the closing brace moves it up again.

Skip that second ascent when the current property is already the containing tree. Add regression tests covering the reported nesting, object/array values, following siblings, empty containers, comments and repeated sorting.

Testing:
- All seven new regression tests fail against the original implementation and pass with the fix.
- `npm test`: compilation, 5,353 tests and nine lint checks passed on Node 22.23.1.
- `git diff --check`: passed.

The change preserves the public API and existing sorting/comma-normalization behavior. No dependencies changed.

Fixes #266.

Prepared with Codex assistance; the checks above were executed locally.
