### PR TITLE
Resolve percent-encoded fragments in JSON reference links

### DIFF
--- a/src/services/jsonLinks.ts
+++ b/src/services/jsonLinks.ts
@@ -31,6 +31,15 @@ function createRange(document: TextDocument, node: ASTNode): Range {
 }
 
 function findTargetNode(doc: JSONDocument, path: string): ASTNode | null {
+	const hashIndex = path.indexOf('#');
+	if (hashIndex >= 0) {
+		try {
+			path = path.substring(0, hashIndex + 1) + decodeURIComponent(path.substring(hashIndex + 1));
+		} catch {
+			// Preserve support for existing references with literal, malformed percent escapes.
+		}
+	}
+
 	const tokens = parseJSONPointer(path);
 	if (tokens) {
 		return findNode(tokens, doc.root);
@@ -46,7 +55,6 @@ function findTargetNode(doc: JSONDocument, path: string): ASTNode | null {
 	}
 
 	// Check for references to embedded schemas by $id (e.g. "https://example.com/embedded")
-	const hashIndex = path.indexOf('#');
 	const uri = hashIndex >= 0 ? path.substring(0, hashIndex) : path;
 	const fragment = hashIndex >= 0 ? path.substring(hashIndex + 1) : undefined;
 

--- a/src/test/links.test.ts
+++ b/src/test/links.test.ts
@@ -54,6 +54,55 @@ suite('JSON Find Links', () => {
 		await testFindLinksFor(doc('#/m~0n'), {target: 90, offset: 102, length: 6});
 	});
 
+	for (const [key, fragment] of [
+		['foo:bar', '#/$defs/foo%3Abar'],
+		['foo bar', '#/$defs/foo%20bar'],
+		['café', '#/$defs/caf%C3%A9'],
+		['a/b', '#/$defs/a%7E1b'],
+		['m~n', '#/$defs/m%7E0n'],
+		['%20', '#/$defs/%2520'],
+		['foo', '#%2F$defs%2Ffoo']
+	]) {
+		test(`FindDefinition percent-encoded pointer ${fragment}`, async function () {
+			const value = JSON.stringify({ $defs: { [key]: { type: 'string' } }, $ref: fragment });
+			await testFindLinksFor(value, {
+				target: value.indexOf('{"type"'),
+				offset: value.indexOf(fragment),
+				length: fragment.length
+			});
+		});
+	}
+
+	test('FindDefinition percent-encoded anchor', async function () {
+		const value = '{"$defs":{"x":{"$anchor":"myAnchor"}},"$ref":"#my%41nchor"}';
+		await testFindLinksFor(value, { target: value.indexOf('{"$anchor"'), offset: value.indexOf('#my'), length: 11 });
+	});
+
+	test('FindDefinition encoded fragment in embedded schema', async function () {
+		const uri = 'https://example.com/schema%20name';
+		for (const fragment of ['#/$defs/foo%20bar', '#my%41nchor']) {
+			const ref = uri + fragment;
+			const value = JSON.stringify({
+				$defs: { embedded: { $id: uri, $defs: { 'foo bar': { $anchor: 'myAnchor' } } } },
+				$ref: ref
+			});
+			await testFindLinksFor(value, {
+				target: value.indexOf('{"$anchor"'),
+				offset: value.indexOf(ref),
+				length: ref.length
+			});
+		}
+	});
+
+	test('FindDefinition malformed percent escapes', async function () {
+		for (const key of ['%', '%GG', '%C3']) {
+			const ref = `#/${key}`;
+			const value = JSON.stringify({ [key]: 1, $ref: ref });
+			await testFindLinksFor(value, { target: value.indexOf(':1') + 1, offset: value.indexOf(ref), length: ref.length });
+			await testFindLinksFor(JSON.stringify({ $ref: ref }), null);
+		}
+	});
+
 	test('FindDefinition anchor reference ($anchor)', async function () {
 		// $anchor in $defs
 		const schema1 = '{"$defs": {"foo": {"$anchor": "myAnchor", "type": "string"}}, "properties": {"x": {"$ref": "#myAnchor"}}}';


### PR DESCRIPTION
Document links for references such as `#/$defs/foo%3Abar` do not reach the `foo:bar` definition, even though current schema validation resolves it correctly. Link resolution matches the encoded text directly against property and anchor names.

Decode the URI fragment once before resolving JSON Pointer tokens or anchors. Keep the URI before `#` unchanged, including when the reference targets an embedded schema. Preserve the existing literal interpretation of malformed percent escapes so malformed input does not throw or break existing links.

Tests:

- Nine new regression tests fail before the fix; the malformed-input compatibility control already passes. All ten pass afterward.
- Cover colon/space/Unicode decoding, tilde and slash escapes, encoded separators, single decoding, anchors, embedded schemas and malformed input. Assertions verify the target location and reference range.
- `npm test` on Node 22.23.1 passes compilation, 5,356 tests and nine lint checks; untouched upstream passed 5,346 tests and nine lint checks.
- `git diff --check` passes.

No public API or dependency changes. This fixes document-link navigation; it does not change schema-validation behavior. Fragment handling follows the URI representation of JSON Pointer described in RFC 6901 section 6.

Related to #281.

Prepared with Codex assistance; the validation above ran locally.
