### PR TITLE
Isolate concurrent schema resolution state

### DIFF
--- a/src/services/jsonSchemaService.ts
+++ b/src/services/jsonSchemaService.ts
@@ -141,7 +141,6 @@ class SchemaHandle implements ISchemaHandle {
 
 	public readonly uri: string;
 	public readonly dependencies: SchemaDependencies;
-	public anchors: Map<string, JSONSchema> | undefined;
 	private resolvedSchema: PromiseLike<ResolvedSchema> | undefined;
 	private unresolvedSchema: PromiseLike<UnresolvedSchema> | undefined;
 	private readonly service: JSONSchemaService;
@@ -150,7 +149,6 @@ class SchemaHandle implements ISchemaHandle {
 		this.service = service;
 		this.uri = uri;
 		this.dependencies = new Set();
-		this.anchors = undefined;
 		if (unresolvedSchemaContent) {
 			this.unresolvedSchema = this.service.promise.resolve(new UnresolvedSchema(unresolvedSchemaContent));
 		}
@@ -177,14 +175,12 @@ class SchemaHandle implements ISchemaHandle {
 		this.resolvedSchema = undefined;
 		this.unresolvedSchema = undefined;
 		this.dependencies.clear();
-		this.anchors = undefined;
 		return hasChanges;
 	}
 
 	public setSchemaContent(schemaContent: JSONSchema): void {
 		this.unresolvedSchema = this.service.promise.resolve(new UnresolvedSchema(schemaContent));
 		this.resolvedSchema = undefined;
-		this.anchors = undefined;
 	}
 }
 
@@ -504,7 +500,20 @@ export class JSONSchemaService implements IJSONSchemaService {
 	public resolveSchemaContent(schemaToResolve: UnresolvedSchema, handle: SchemaHandle): PromiseLike<ResolvedSchema> {
 
 		const resolveErrors: SchemaDiagnostic[] = schemaToResolve.errors.slice(0);
-		const schema = schemaToResolve.schema;
+		const schema = copySchema(schemaToResolve.schema);
+		const anchors = new Map<JSONSchema, Map<string, JSONSchema>>();
+		const unresolvedSchemas = new Map<SchemaHandle, PromiseLike<UnresolvedSchema>>([
+			[handle, this.promise.resolve(new UnresolvedSchema(schema, schemaToResolve.errors))]
+		]);
+		// Share downloads, but keep the graph mutated by reference resolution local to this pass.
+		const getUnresolvedSchema = (schemaHandle: SchemaHandle): PromiseLike<UnresolvedSchema> => {
+			let unresolved = unresolvedSchemas.get(schemaHandle);
+			if (!unresolved) {
+				unresolved = schemaHandle.getUnresolvedSchema().then(content => new UnresolvedSchema(copySchema(content.schema), content.errors));
+				unresolvedSchemas.set(schemaHandle, unresolved);
+			}
+			return unresolved;
+		};
 
 		// External documents whose embedded $id resources have already been registered
 		// as resolvable handles, so we only do it once per referenced document.
@@ -608,11 +617,13 @@ export class JSONSchemaService implements IJSONSchemaService {
 			return { section: current, baseHandle: currentBaseHandle };
 		};
 
-		const findSchemaById = (schema: JSONSchema, handle: SchemaHandle, id: string) => {
-			if (!handle.anchors) {
-				handle.anchors = collectAnchors(schema);
+		const findSchemaById = (schema: JSONSchema, id: string) => {
+			let schemaAnchors = anchors.get(schema);
+			if (!schemaAnchors) {
+				schemaAnchors = collectAnchors(schema);
+				anchors.set(schema, schemaAnchors);
 			}
-			return handle.anchors.get(id);
+			return schemaAnchors.get(id);
 		};
 
 		const getSchemaId = (schema: JSONSchema): string | undefined => schema.$id || schema.id || (schema as MergedJSONSchema).$originalId;
@@ -799,7 +810,7 @@ export class JSONSchemaService implements IJSONSchemaService {
 				({ section, baseHandle: sectionBaseHandle } = findSectionAndBase(sourceRoot, refSegment, sourceHandle));
 			} else {
 				// A $ref to a sub-schema with an $id (i.e #hello)
-				section = findSchemaById(sourceRoot, sourceHandle, refSegment);
+				section = findSchemaById(sourceRoot, refSegment);
 			}
 			// A boolean is a valid JSON Schema: `true` accepts everything ({}) and
 			// `false` rejects everything ({ not: {} }). Normalize so it merges like any
@@ -899,7 +910,7 @@ export class JSONSchemaService implements IJSONSchemaService {
 		const resolveExternalLink = (node: JSONSchema, uri: string, refSegment: string | undefined, parentHandle: SchemaHandle, continuationBase?: JSONSchema, continuationHandle?: SchemaHandle, followedRedirects = new Set<string>()): PromiseLike<any> => {
 			const referencedHandle = getExternalSchemaHandle(uri, parentHandle);
 			uri = referencedHandle.uri;
-			return referencedHandle.getUnresolvedSchema().then(unresolvedSchema => {
+			return getUnresolvedSchema(referencedHandle).then(unresolvedSchema => {
 				parentHandle.dependencies.add(uri);
 				const rootRef = unresolvedSchema.schema.$ref;
 				const alreadyFollowed = followedRedirects.has(uri);
@@ -1269,17 +1280,18 @@ export class JSONSchemaService implements IJSONSchemaService {
 					}
 					const existingHandle = this.schemasById[resolvedUri];
 					if (!existingHandle) {
-						this.addSchemaHandle(resolvedUri, node);
+						this.addSchemaHandle(resolvedUri, copySchema(node));
 					} else if (existingHandle !== handle) {
 						// Update existing handle with embedded schema content.
 						// This ensures embedded schemas take precedence over external schemas.
 						// Skip when the existing handle is the handle currently being resolved
 						// (i.e. the root schema's own $id matches its retrieval URI): overwriting
-						// it here would reset its cache mid-resolution using the same object
-						// reference that this resolution pass is still mutating (merging $refs
-						// into), silently discarding any resolveErrors accumulated so far on the
-						// next time this handle is resolved.
-						existingHandle.setSchemaContent(node);
+						// it here would reset its cache mid-resolution and discard load errors.
+						existingHandle.setSchemaContent(copySchema(node));
+					}
+					// Embedded resources must refer to the same local nodes as their containing document.
+					if (this.schemasById[resolvedUri] !== handle) {
+						unresolvedSchemas.set(this.schemasById[resolvedUri], this.promise.resolve(new UnresolvedSchema(node)));
 					}
 					newBaseUri = resolvedUri;
 				}
@@ -1299,7 +1311,7 @@ export class JSONSchemaService implements IJSONSchemaService {
 		// Collect anchors eagerly before $ref resolution mutates the schema.
 		// resolveRefs merges referenced nodes (including $anchor) into $ref targets,
 		// so a lazy collectAnchors call could see duplicates from merged copies.
-		handle.anchors = collectAnchors(schema);
+		anchors.set(schema, collectAnchors(schema));
 
 		// Collect $dynamicAnchor maps eagerly too, for the same reason: resource
 		// boundaries must be read before $ref resolution flattens them.
@@ -1451,4 +1463,28 @@ function toDisplayString(url: string) {
 		// ignore
 	}
 	return url;
+}
+
+// Preserve shared nodes and cycles within one copy, without sharing mutable JSON data across resolutions.
+function copySchema(schema: JSONSchema): JSONSchema {
+	const copies = new Map<object, any>();
+	const copy = (value: any): any => {
+		if (!value || typeof value !== 'object') {
+			return value;
+		}
+		const prototype = Object.getPrototypeOf(value);
+		if (!Array.isArray(value) && prototype !== Object.prototype && prototype !== null) {
+			return value;
+		}
+		if (copies.has(value)) {
+			return copies.get(value);
+		}
+		const result: any = Array.isArray(value) ? value.slice() : { ...value };
+		copies.set(value, result);
+		for (const key of Object.keys(result)) {
+			result[key] = copy(result[key]);
+		}
+		return result;
+	};
+	return copy(schema);
 }

--- a/src/test/schema.test.ts
+++ b/src/test/schema.test.ts
@@ -154,6 +154,112 @@ suite('JSON Schema', () => {
 		assert.ok(secondRequestedBeforeFirstResolved, 'Expected sibling external schemas to be requested concurrently');
 	});
 
+	suite('Concurrent schema resolution', () => {
+		for (const referenceKind of ['document', 'standalone', 'anchor', 'embedded']) {
+			for (const failNestedRequest of [false, true]) {
+				test(`${referenceKind} references wait for nested ${failNestedRequest ? 'failure' : 'completion'}`, async function () {
+					const sharedUri = 'https://example.com/shared.json';
+					const nestedUri = 'https://example.com/nested.json';
+					const embeddedUri = 'https://example.com/embedded.json';
+					const payload: JSONSchema = { type: 'object', properties: { value: { $ref: nestedUri } } };
+					let sharedSchema = payload;
+					let reference = sharedUri;
+					if (referenceKind === 'anchor' || referenceKind === 'embedded') {
+						sharedSchema = { $defs: { payload } };
+						if (referenceKind === 'anchor') {
+							payload.$anchor = 'payload';
+							reference += '#payload';
+						} else {
+							payload.$id = embeddedUri;
+							reference += '#/$defs/payload';
+						}
+					}
+					let finishNested!: (value: string) => void;
+					let failNested!: (reason: Error) => void;
+					let signalNested!: () => void;
+					const nestedRequested = new Promise<void>(resolve => signalNested = resolve);
+					const requests: string[] = [];
+					const service = new SchemaService.JSONSchemaService(uri => {
+						requests.push(uri);
+						if (uri === sharedUri) {
+							return Promise.resolve(JSON.stringify(sharedSchema));
+						}
+						assert.strictEqual(uri, nestedUri);
+						signalNested();
+						return new Promise<string>((resolve, reject) => {
+							finishNested = resolve;
+							failNested = reject;
+						});
+					}, workspaceContext);
+					const firstHandle = service.registerExternalSchema(referenceKind === 'standalone'
+						? { uri: sharedUri }
+						: { uri: 'https://example.com/first.json', schema: { $ref: reference } });
+					const secondHandle = service.registerExternalSchema({ uri: 'https://example.com/second.json', schema: { $ref: referenceKind === 'embedded' ? embeddedUri : reference } });
+					const first = firstHandle.getResolvedSchema();
+					await nestedRequested;
+					let secondResolved = false;
+					const second = secondHandle.getResolvedSchema().then(result => {
+						secondResolved = true;
+						return result;
+					});
+					// Drain promise callbacks while the nested request is explicitly held open.
+					await new Promise<void>(resolve => setImmediate(resolve));
+					const resolvedEarly = secondResolved;
+					if (failNestedRequest) {
+						failNested(new Error('nested schema unavailable'));
+					} else {
+						finishNested(JSON.stringify({ type: 'string' }));
+					}
+					const results = await Promise.all([first, second]);
+					assert.strictEqual(resolvedEarly, false, 'Every root must wait for its nested reference');
+					assert.deepStrictEqual(requests, [sharedUri, nestedUri], 'Downloads should remain cached across roots');
+					for (const result of results) {
+						if (failNestedRequest) {
+							assert.strictEqual(result.errors.length, 1);
+							assertInMessage(result.errors[0].message, 'nested schema unavailable');
+						} else {
+							assert.deepStrictEqual(result.errors, []);
+							assert.strictEqual((result.schema.properties?.value as JSONSchema).type, 'string');
+						}
+					}
+				});
+			}
+		}
+
+		test('invalidation refreshes nested references without changing settled results', async function () {
+			const sharedUri = 'https://example.com/shared.json';
+			const nestedUri = 'https://example.com/nested.json';
+			const rootUri = 'https://example.com/root.json';
+			const requests: string[] = [];
+			let nestedType = 'string';
+			const service = new SchemaService.JSONSchemaService(uri => {
+				if (uri === rootUri) {
+					return Promise.resolve(JSON.stringify({ $ref: sharedUri }));
+				}
+				requests.push(uri);
+				assert.ok(uri === sharedUri || uri === nestedUri);
+				return Promise.resolve(JSON.stringify(uri === sharedUri
+					? { type: 'object', properties: { value: { $ref: nestedUri }, next: { $ref: sharedUri } } }
+					: { type: nestedType }));
+			}, workspaceContext);
+			const root = service.registerExternalSchema({ uri: rootUri });
+			const first = await root.getResolvedSchema();
+			assert.deepStrictEqual(first.errors, []);
+			assert.strictEqual((first.schema.properties?.value as JSONSchema).type, 'string');
+			assert.strictEqual(((first.schema.properties?.next as JSONSchema).properties?.value as JSONSchema).type, 'string');
+			nestedType = 'number';
+			assert.ok(service.onResourceChange(nestedUri));
+			const second = await root.getResolvedSchema();
+			assert.ok(second);
+			assert.deepStrictEqual(second.errors, []);
+			assert.strictEqual((second.schema.properties?.value as JSONSchema).type, 'number');
+			assert.strictEqual(((second.schema.properties?.next as JSONSchema).properties?.value as JSONSchema).type, 'number');
+			assert.strictEqual((first.schema.properties?.value as JSONSchema).type, 'string');
+			assert.strictEqual(((first.schema.properties?.next as JSONSchema).properties?.value as JSONSchema).type, 'string');
+			assert.deepStrictEqual(requests, [sharedUri, nestedUri, sharedUri, nestedUri]);
+		});
+	});
+
 	test('Resolving $refs', async function () {
 		const service = new SchemaService.JSONSchemaService(newMockRequestService(), workspaceContext);
 		service.setSchemaContributions({


### PR DESCRIPTION
When two roots resolve the same external schema concurrently, the second can finish while a nested request is still pending. Its returned schema then changes after resolution; failed nested requests can also be missing from its diagnostics.

Reference merging currently shares nested objects from cached unresolved schemas. Deleting a `$ref` in one resolution therefore makes another resolution treat the same node as complete.

This change gives each resolution its own mutable schema graph while retaining the shared download cache and existing merge behavior. Anchor lookup belongs to that graph, and embedded resources keep local aliases without exposing those nodes through globally cached handles. The copies preserve shared nodes and cycles within each copied document.

Validation on Node 22.23.1, macOS arm64:

- Added eight controlled concurrency regressions covering document references, overlapping standalone resolution, anchors, embedded IDs, and successful/failed nested requests. All eight fail against unchanged `75a46d7d` because the second result resolves early, and pass with this patch.
- Added a passing compatibility check for cyclic references, dependency invalidation, and stability of previously resolved results.
- `npm test`: compilation, 5,355 tests, and 9 lint checks passed. The unchanged baseline passed 5,346 tests and 9 lint checks.

The isolation adds in-memory copying per resolution; no performance improvement is claimed. Download reuse is asserted in the regressions. Public API signatures and reference merge rules are unchanged.

Fixes #350.

AI assistance: implemented and validated with OpenAI Codex.
